### PR TITLE
Fix problem parsing drug central

### DIFF
--- a/kg_emerging_viruses/transform_utils/drug_central/drug_central.py
+++ b/kg_emerging_viruses/transform_utils/drug_central/drug_central.py
@@ -3,6 +3,7 @@
 
 
 import gzip
+import logging
 import os
 
 from typing import Dict, List
@@ -60,6 +61,13 @@ class DrugCentralTransform(Transform):
                 # get gene ID
                 gene_id = get_item_by_priority(items_dict, ['ACCESSION'])
 
+                if gene_id is None:
+                    # lines with no ACCESSION entry only contain drug info, no target
+                    # info - not ingesting these
+                    logging.info(
+                        "No gene information for this line:\n{}\nskipping".format(line))
+                    continue
+
                 # get drug ID
                 drug_id = get_item_by_priority(items_dict,
                                                ['ACT_SOURCE_URL',
@@ -74,7 +82,6 @@ class DrugCentralTransform(Transform):
                                            items_dict['DRUG_NAME'],
                                            drug_node_type])
 
-                # gene - ['id', 'name', 'category']
                 write_node_edge_item(fh=node,
                                      header=self.node_header,
                                      data=[gene_id,

--- a/kg_emerging_viruses/utils/transform_utils.py
+++ b/kg_emerging_viruses/utils/transform_utils.py
@@ -63,7 +63,10 @@ def write_node_edge_item(fh: Any, header: List, data: List, sep: str = '\t') -> 
     if len(header) != len(data):
         raise Exception('Header and data are not the same length.')
     else:
-        fh.write(sep.join(data) + "\n")
+        try:
+            fh.write(sep.join(data) + "\n")
+        except:
+            logging.warning("Can't write data for {}".format(data))
 
     return None
 


### PR DESCRIPTION
 - several lines contain only drug info, no target info, example:

```
"phenylbutanoic acid"   24      "glutamine"     "Amino acid"                                                    "Mechanism of Action"   "DRUG LABEL"            1       "DRUG LABEL"            "http://www.accessdata.fda.gov/drugsatfda_docs/label/2009/020572s016,020573s015lbl.pdf" "OTHER"
```

skipping these lines