### PR TITLE
Configurable transform and proper handling of input and output directory

### DIFF
--- a/kg_covid_19/transform.py
+++ b/kg_covid_19/transform.py
@@ -18,7 +18,7 @@ DATA_SOURCES = {
     'StringTransform': StringTransform,
 }
 
-def transform(input_dir: str, output_dir: str, sources: List = None) -> None:
+def transform(input_dir: str, output_dir: str, sources: List[str] = None) -> None:
     """Call scripts in kg_covid_19/transform/[source name]/ to transform each source into a graph format that
     KGX can ingest directly, in either TSV or JSON format:
     https://github.com/NCATS-Tangerine/kgx/blob/master/data-preparation.md
@@ -34,7 +34,7 @@ def transform(input_dir: str, output_dir: str, sources: List = None) -> None:
     """
     if not sources:
         # run all sources
-        sources = DATA_SOURCES.keys()
+        sources = list(DATA_SOURCES.keys())
 
     for source in sources:
         if source in DATA_SOURCES:

--- a/kg_covid_19/transform.py
+++ b/kg_covid_19/transform.py
@@ -13,7 +13,9 @@ from kg_covid_19.transform_utils.zhou_host_proteins.zhou_transform import ZhouTr
 DATA_SOURCES = {
     'ZhouTransform': ZhouTransform,
     'DrugCentralTransform': DrugCentralTransform,
-    'StringTransform': StringTransform
+    'HpoTransform': HpoTransform,
+    'TTDTransform': TTDTransform,
+    'StringTransform': StringTransform,
 }
 
 def transform(input_dir: str, output_dir: str, sources: List = None) -> None:

--- a/kg_covid_19/transform.py
+++ b/kg_covid_19/transform.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from typing import List
 
-
-from kg_covid_19.transform_utils import zhou_transform
 from kg_covid_19.transform_utils.drug_central.drug_central import DrugCentralTransform
 from kg_covid_19.transform_utils.string_ppi import StringTransform
 from kg_covid_19.transform_utils.zhou_host_proteins.zhou_transform import ZhouTransform
 
 
-def transform(input_dir: str, output_dir: str) -> None:
+DATA_SOURCES = {
+    'ZhouTransform': ZhouTransform,
+    'DrugCentralTransform': DrugCentralTransform,
+    'StringTransform': StringTransform
+}
+
+def transform(input_dir: str, output_dir: str, sources: List = None) -> None:
     """Call scripts in kg_covid_19/transform/[source name]/ to transform each source into a graph format that
     KGX can ingest directly, in either TSV or JSON format:
     https://github.com/NCATS-Tangerine/kgx/blob/master/data-preparation.md
@@ -16,17 +21,20 @@ def transform(input_dir: str, output_dir: str) -> None:
     Args:
         input_dir: A string pointing to the directory to import data from.
         output_dir: A string pointing to the directory to output data to.
+        sources: A list of sources to transform.
 
     Returns:
         None.
     """
+    if not sources:
+        # run all sources
+        sources = DATA_SOURCES.keys()
 
-    # call transform script for each source
-    zt = ZhouTransform()
-    zt.run()
-
-    dct = DrugCentralTransform()
-    dct.run()
-
-    string_ppi = StringTransform(input_dir, output_dir)
-    string_ppi.run()
+    for source in sources:
+        print(source)
+        if source in DATA_SOURCES:
+            if source == 'StringTransform':
+                t = DATA_SOURCES[source](input_dir, output_dir)
+            else:
+                t = DATA_SOURCES[source]()
+            t.run()

--- a/kg_covid_19/transform.py
+++ b/kg_covid_19/transform.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import logging
 from typing import List
 
 from kg_covid_19.transform_utils.drug_central.drug_central import DrugCentralTransform
@@ -25,16 +26,14 @@ def transform(input_dir: str, output_dir: str, sources: List = None) -> None:
 
     Returns:
         None.
+
     """
     if not sources:
         # run all sources
         sources = DATA_SOURCES.keys()
 
     for source in sources:
-        print(source)
         if source in DATA_SOURCES:
-            if source == 'StringTransform':
-                t = DATA_SOURCES[source](input_dir, output_dir)
-            else:
-                t = DATA_SOURCES[source]()
+            logging.info(f"Parsing {source}")
+            t = DATA_SOURCES[source](input_dir, output_dir)
             t.run()

--- a/kg_covid_19/transform_utils/drug_central/drug_central.py
+++ b/kg_covid_19/transform_utils/drug_central/drug_central.py
@@ -24,8 +24,9 @@ And extracts Drug -> Gene interactions
 
 class DrugCentralTransform(Transform):
 
-    def __init__(self) -> None:
-        super().__init__(source_name="drug_central")  # set some variables
+    def __init__(self, input_dir: str = None, output_dir: str = None) -> None:
+        source_name = "drug_central"
+        super().__init__(source_name, input_dir, output_dir)  # set some variables
 
     def run(self) -> None:
         """Method is called and performs needed transformations to process the Drug Central data, additional information

--- a/kg_covid_19/transform_utils/hpo/hpo.py
+++ b/kg_covid_19/transform_utils/hpo/hpo.py
@@ -20,8 +20,9 @@ GitHub Issue: https://github.com/Knowledge-Graph-Hub/kg-covid-19/issues/48
 
 class HpoTransform(Transform):
 
-    def __init__(self):
-        super().__init__(source_name="hpo")
+    def __init__(self, input_dir: str = None, output_dir: str = None):
+        source_name = "hpo"
+        super().__init__(source_name, input_dir, output_dir)
 
     def run(self):
         self.node_header.extend(["comments", "description"])
@@ -29,9 +30,6 @@ class HpoTransform(Transform):
         hpo_edge_label = "rdfs:subClassOf"
         hpo_ro_relation = "RO:0002351"
         hpo_obo_file = os.path.join(self.input_base_dir, "hp.obo")
-
-        # make directory in data/transformed
-        os.makedirs(self.output_dir, exist_ok=True)
 
         # transform data, something like:
         with open(self.output_node_file, 'w') as node, \

--- a/kg_covid_19/transform_utils/string_ppi/string_ppi.py
+++ b/kg_covid_19/transform_utils/string_ppi/string_ppi.py
@@ -33,15 +33,15 @@ class StringTransform(Transform):
     """
     StringTransform parses interactions from STRING DB into nodes and edges.
     """
-    def __init__(self, input_dir: str, output_dir: str):
-        super().__init__(source_name="STRING")
-        self.input_dir = input_dir
-        self.output_dir = output_dir
+    def __init__(self, input_dir: str = None, output_dir: str = None):
+        source_name = "STRING"
+        super().__init__(source_name, input_dir, output_dir)
+
         self.protein_gene_map: Dict[str, Any] = {}
         self.gene_info_map: Dict[str, Any] = {}
         self.ensembl2ncbi_map: Dict[str, Any] = {}
-        self.load_mapping(input_dir, output_dir, ['9606'])
-        self.load_gene_info(input_dir, output_dir, ['9606'])
+        self.load_mapping(self.input_base_dir, output_dir, ['9606'])
+        self.load_gene_info(self.input_base_dir, output_dir, ['9606'])
 
 
     def load_mapping(self, input_dir: str, output_dir: str, species_id: List = None) -> None:
@@ -59,8 +59,7 @@ class StringTransform(Transform):
         if not species_id:
             # default to just human
             species_id = ['9606']
-        file_path = os.path.join(self.input_base_dir, PROTEIN_MAPPING_FILE)
-
+        file_path = os.path.join(input_dir, PROTEIN_MAPPING_FILE)
         with gzip.open(file_path, 'rt') as FH:
             for line in FH:
                 records = line.split('\t')
@@ -119,7 +118,7 @@ class StringTransform(Transform):
 
         """
         if not data_file:
-            data_file = os.path.join(self.input_dir, "9606.protein.links.full.v11.0.txt.gz")
+            data_file = os.path.join(self.input_base_dir, "9606.protein.links.full.v11.0.txt.gz")
         os.makedirs(self.output_dir, exist_ok=True)
         protein_node_type = "biolink:Protein"
         edge_label = "biolink:interacts_with"

--- a/kg_covid_19/transform_utils/string_ppi/string_ppi.py
+++ b/kg_covid_19/transform_utils/string_ppi/string_ppi.py
@@ -40,8 +40,8 @@ class StringTransform(Transform):
         self.protein_gene_map: Dict[str, Any] = {}
         self.gene_info_map: Dict[str, Any] = {}
         self.ensembl2ncbi_map: Dict[str, Any] = {}
-        self.load_mapping(self.input_base_dir, output_dir, ['9606'])
-        self.load_gene_info(self.input_base_dir, output_dir, ['9606'])
+        self.load_mapping(self.input_base_dir, self.output_dir, ['9606'])
+        self.load_gene_info(self.input_base_dir, self.output_dir, ['9606'])
 
 
     def load_mapping(self, input_dir: str, output_dir: str, species_id: List = None) -> None:
@@ -132,7 +132,7 @@ class StringTransform(Transform):
         ]
         self.edge_header = edge_core_header + edge_additional_headers
         relation = 'RO:0002434'
-        seen = []
+        seen: List = []
 
         with open(self.output_node_file, 'w') as node, \
                 open(self.output_edge_file, 'w') as edge, \

--- a/kg_covid_19/transform_utils/transform.py
+++ b/kg_covid_19/transform_utils/transform.py
@@ -27,3 +27,5 @@ class Transform:
         self.output_json_file = os.path.join(self.output_dir, "nodes_edges.json")
 
 
+    def run(self):
+        pass

--- a/kg_covid_19/transform_utils/transform.py
+++ b/kg_covid_19/transform_utils/transform.py
@@ -5,7 +5,10 @@ class Transform:
     """Parent class for transforms, that sets up a lot of default file info
     """
 
-    def __init__(self, source_name):
+    DEFAULT_INPUT_DIR = os.path.join('data', 'raw')
+    DEFAULT_OUTPUT_DIR = os.path.join('data', 'transformed')
+
+    def __init__(self, source_name, input_dir: str = None, output_dir: str = None):
         # default columns, can be appended to or overwritten as necessary
         self.source_name = source_name
         self.node_header = ['id', 'name', 'category']
@@ -13,9 +16,10 @@ class Transform:
                             'publications']
 
         # default dirs
-        self.output_base_dir = os.path.join("data", "transformed")
-        self.input_base_dir = os.path.join("data", "raw")
+        self.input_base_dir = input_dir if input_dir else self.DEFAULT_INPUT_DIR
+        self.output_base_dir = output_dir if output_dir else self.DEFAULT_OUTPUT_DIR
         self.output_dir = os.path.join(self.output_base_dir, source_name)
+        os.makedirs(self.output_dir, exist_ok=True)
 
         # default filenames
         self.output_node_file = os.path.join(self.output_dir, "nodes.tsv")

--- a/kg_covid_19/transform_utils/ttd/ttd.py
+++ b/kg_covid_19/transform_utils/ttd/ttd.py
@@ -25,13 +25,11 @@ class TTDNotEnoughFields(Exception):
 
 class TTDTransform(Transform):
 
-    def __init__(self):
-        super().__init__(source_name="ttd")
+    def __init__(self, input_dir: str = None, output_dir: str = None):
+        source_name = "ttd"
+        super().__init__(source_name, input_dir, output_dir)
 
     def run(self) -> None:
-        # make directory in data/transformed
-        os.makedirs(self.output_dir, exist_ok=True)
-
         self.node_header.append("TTD_ID") # append ttd id for drug targets and drugs
         ttd_file_name = os.path.join(self.input_base_dir,
                                      "P1-01-TTD_target_download.txt")

--- a/kg_covid_19/transform_utils/zhou_host_proteins/zhou_transform.py
+++ b/kg_covid_19/transform_utils/zhou_host_proteins/zhou_transform.py
@@ -30,14 +30,15 @@ gene:1234  contributes_to_condition    MONDO:0005002   RO:0003304
 
 class ZhouTransform(Transform):
 
-    def __init__(self) -> None:
-        super().__init__(source_name="zhou_host_proteins")
+    def __init__(self, input_dir: str = None, output_dir: str = None) -> None:
+        source_name = "zhou_host_proteins"
+        super().__init__(source_name, input_dir, output_dir)
 
     def run(self) -> None:
         """Method is called and performs needed transformations to process the zhou host protein data, additional
         information on this data can be found in the comment at the top of this script."""
 
-        input_file = os.path.join('data', 'raw', '41421_2020_153_MOESM1_ESM.pdf')
+        input_file = os.path.join(self.input_base_dir, '41421_2020_153_MOESM1_ESM.pdf')
 
         pubmed_curie_prefix = 'PMID:'
         gene_curie_prefix = 'NCBI:'

--- a/run.py
+++ b/run.py
@@ -6,7 +6,7 @@ import click
 from kg_covid_19 import download as kg_download
 from kg_covid_19 import transform as kg_transform
 from kg_covid_19.load_utils.merge_kg import load_and_merge
-
+from kg_covid_19.transform import DATA_SOURCES
 
 @click.group()
 def cli():
@@ -22,8 +22,14 @@ def download(*args, **kwargs) -> None:
     """Downloads data files from list of URLs (default: download.yaml) into data
     directory (default: data/raw).
 
+    Args:
+        input_dir: A string pointing to the directory to import data from.
+        output_dir: A string pointing to the directory to output data to.
+        ignore_cache: If specified, will ignore existing files and download again.
+
     Returns:
         None.
+
     """
 
     kg_download(*args, **kwargs)
@@ -34,12 +40,19 @@ def download(*args, **kwargs) -> None:
 @cli.command()
 @click.option("input_dir", "-i", default="data/raw", type=click.Path(exists=True))
 @click.option("output_dir", "-o", default="data/transformed")
+@click.option("sources", "-s", default=None, multiple=True, type=click.Choice(DATA_SOURCES.keys()))
 def transform(*args, **kwargs) -> None:
     """Calls scripts in kg_covid_19/transform/[source name]/ to transform each source
-    into nodes and edges
+    into nodes and edges.
+
+    Args:
+        input_dir: A string pointing to the directory to import data from.
+        output_dir: A string pointing to the directory to output data to.
+        sources: A list of sources to transform.
 
     Returns:
         None.
+
     """
 
     # call transform script for each source
@@ -57,6 +70,7 @@ def load(yaml: str) -> None:
 
     Returns:
         None.
+
     """
 
     load_and_merge(yaml)

--- a/run.py
+++ b/run.py
@@ -23,8 +23,8 @@ def download(*args, **kwargs) -> None:
     directory (default: data/raw).
 
     Args:
-        input_dir: A string pointing to the directory to import data from.
-        output_dir: A string pointing to the directory to output data to.
+        yaml_file: Specify the YAML file containing a list of datasets to download.
+        output_dir: A string pointing to the directory to download data to.
         ignore_cache: If specified, will ignore existing files and download again.
 
     Returns:


### PR DESCRIPTION
This PR address #59 and also allows for configurable transform.
This is useful when we want to run just handful of sources instead of all of them.

To run your transforms,
```
python run.py download -s HpoTransform -s TTDTransform
```

If nothing is provided then it runs all the transforms as defined in `kg_covid_19/transform.py`.