### PR TITLE
Update load_and_merge operation to support more than one destination 

### DIFF
--- a/kg_covid_19/load_utils/merge_kg.py
+++ b/kg_covid_19/load_utils/merge_kg.py
@@ -68,19 +68,20 @@ def load_and_merge(yaml_file: str) -> nx.MultiDiGraph:
 
     # write the merged graph
     if 'destination' in config:
-        destination = config['destination']
-        if destination['type'] in ['csv', 'tsv', 'ttl', 'json', 'tar']:
-            destination_transformer = get_transformer(destination['type'])(merged_graph)
-            destination_transformer.save(destination['filename'], extension=destination['type'])
-        elif destination['type'] == 'neo4j':
-            destination_transformer = NeoTransformer(
-                merged_graph,
-                uri=destination['uri'],
-                username=destination['username'],
-                password=destination['password']
-            )
-            destination_transformer.save_with_unwind()
-        else:
-            logging.error("type {} not yet supported for KGX load-and-merge operation.".format(destination['type']))
+        for _, destination in config['destination'].items():
+            print(destination)
+            if destination['type'] == 'neo4j':
+                destination_transformer = NeoTransformer(
+                    merged_graph,
+                    uri=destination['uri'],
+                    username=destination['username'],
+                    password=destination['password']
+                )
+                destination_transformer.save_with_unwind()
+            elif destination['type'] in get_file_types():
+                destination_transformer = get_transformer(destination['type'])(merged_graph)
+                destination_transformer.save(destination['filename'], extension=destination['type'])
+            else:
+                logging.error("type {} not yet supported for KGX load-and-merge operation.".format(destination['type']))
 
     return merged_graph

--- a/merge.yaml
+++ b/merge.yaml
@@ -56,5 +56,14 @@ target:
          - data/transformed/ontologies/hp_nodes.tsv
          - data/transformed/ontologies/hp_edges.tsv
 destination:
-   type: tsv
-   filename: merged-kg
+   merged-kg-tsv:
+      type: tsv
+      filename: merged-kg
+   merged-kg-nt:
+      type: nt
+      filename: merged-kg.nt
+#   merged-kg-neo4j:
+#      type: neo4j
+#      uri: http://localhost:8484
+#      username: neo4j
+#      password: admin


### PR DESCRIPTION
Now you can run,
```
python run.py load
```
You can create more than one artifact from the merged graph.
This behavior is driven by `merge.yaml`.

To export to Neo4j, uncomment the lines in `merge.yaml`
