### PR TITLE
Update scibite cord ingest

### DIFF
--- a/download.yaml
+++ b/download.yaml
@@ -63,12 +63,18 @@
 -
   url: ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/HUMAN_9606_idmapping.dat.gz
   local_name: HUMAN_9606_idmapping.dat.gz
+
 #
-# SciBite CORD-19 annotations v1.2
+# SciBite CORD-19 annotations v1.4
 #
 -
-  url: https://s3.eu-west-2.amazonaws.com/scibite.covid19data/CORD19/annotated-cord19/CORD-19_1_3.zip
-  local_name: CORD-19_1_3.zip
+  url: https://media.githubusercontent.com/media/SciBiteLabs/CORD19/master/annotated-CORD-19/1.4/CORD-19_1_4.zip
+  local_name: CORD-19_1_4.zip
+
+ # SciBite CORD-19 entity co-occurrences v1.2
+-
+  url: https://media.githubusercontent.com/media/SciBiteLabs/CORD19/master/sentence-co-occurrence-CORD-19/1.2/cv19_scc_1_2.zip
+  local_name: cv19_scc_1_2.zip
 
 #
 # PharmGKB - drug -> drug target info, and gene id mappings

--- a/download.yaml
+++ b/download.yaml
@@ -71,10 +71,10 @@
   url: https://media.githubusercontent.com/media/SciBiteLabs/CORD19/master/annotated-CORD-19/1.4/CORD-19_1_4.zip
   local_name: CORD-19_1_4.zip
 
- # SciBite CORD-19 entity co-occurrences v1.2
--
-  url: https://media.githubusercontent.com/media/SciBiteLabs/CORD19/master/sentence-co-occurrence-CORD-19/1.2/cv19_scc_1_2.zip
-  local_name: cv19_scc_1_2.zip
+# # SciBite CORD-19 entity co-occurrences v1.2
+#-
+#  url: https://media.githubusercontent.com/media/SciBiteLabs/CORD19/master/sentence-co-occurrence-CORD-19/1.2/cv19_scc_1_2.zip
+#  local_name: cv19_scc_1_2.zip
 
 #
 # PharmGKB - drug -> drug target info, and gene id mappings

--- a/download.yaml
+++ b/download.yaml
@@ -71,10 +71,10 @@
   url: https://media.githubusercontent.com/media/SciBiteLabs/CORD19/master/annotated-CORD-19/1.4/CORD-19_1_4.zip
   local_name: CORD-19_1_4.zip
 
-# # SciBite CORD-19 entity co-occurrences v1.2
-#-
-#  url: https://media.githubusercontent.com/media/SciBiteLabs/CORD19/master/sentence-co-occurrence-CORD-19/1.2/cv19_scc_1_2.zip
-#  local_name: cv19_scc_1_2.zip
+ # SciBite CORD-19 entity co-occurrences v1.2
+-
+  url: https://media.githubusercontent.com/media/SciBiteLabs/CORD19/master/sentence-co-occurrence-CORD-19/1.2/cv19_scc_1_2.zip
+  local_name: cv19_scc_1_2.zip
 
 #
 # PharmGKB - drug -> drug target info, and gene id mappings

--- a/kg_covid_19/transform_utils/scibite_cord/scibite_cord.py
+++ b/kg_covid_19/transform_utils/scibite_cord/scibite_cord.py
@@ -44,8 +44,8 @@ class ScibiteCordTransform(Transform):
         """
         data_files = list()
         if not data_file:
-            data_files.append(os.path.join(self.input_base_dir, "CORD-19_1_3.zip"))
-            data_files.append(os.path.join(self.input_base_dir, "cv19_scc.zip"))
+            data_files.append(os.path.join(self.input_base_dir, "CORD-19_1_4.zip"))
+            data_files.append(os.path.join(self.input_base_dir, "cv19_scc_1_2.zip"))
         else:
             data_files.append(data_file)
 

--- a/kg_covid_19/transform_utils/scibite_cord/scibite_cord.py
+++ b/kg_covid_19/transform_utils/scibite_cord/scibite_cord.py
@@ -56,7 +56,12 @@ class ScibiteCordTransform(Transform):
         node_handle.write("\t".join(self.node_header) + "\n")
         edge_handle.write("\t".join(self.edge_header) + "\n")
         self.parse_annotations(node_handle, edge_handle, data_files[0])
-        #self.parse_cooccurrence(node_handle, edge_handle, data_files[1])
+
+        node_handle = open(os.path.join(self.output_dir, "entity_cooccurrence_nodes.tsv"), 'w')
+        edge_handle = open(os.path.join(self.output_dir, "entity_cooccurrence_edges.tsv"), 'w')
+        node_handle.write("\t".join(self.node_header) + "\n")
+        edge_handle.write("\t".join(self.edge_header) + "\n")
+        self.parse_cooccurrence(node_handle, edge_handle, data_files[1])
 
     def parse_annotations(self, node_handle: Any, edge_handle: Any, data_file: str) -> None:
         """Parse annotations from CORD-19_1_2.zip.


### PR DESCRIPTION
This PR bumps up the version of SciBite CORD-19 datasets in `download.yaml`

@justaddcoffee I added back the entity co-occurrence dataset but its not being transformed at the moment. If we transform that dataset, we end up with ~23 million nodes and ~23 million edges just from this ingest. 

Maybe we can enable the transformation later on, if needed.