### PR TITLE
Fix names and symbols for SARS-CoV-2 gene annotation ingest

### DIFF
--- a/kg_covid_19/utils/transform_utils.py
+++ b/kg_covid_19/utils/transform_utils.py
@@ -6,6 +6,7 @@ import zipfile
 from typing import Any, Dict, List, Union, TextIO
 from tqdm import tqdm  # type: ignore
 
+
 class TransformError(Exception):
     """Base class for other exceptions"""
     pass
@@ -102,6 +103,7 @@ def get_item_by_priority(items_dict: dict, keys_by_priority: list) -> str:
         raise ItemInDictNotFound("Can't find item in items_dict {}".format(items_dict))
     return value
 
+
 def data_to_dict(these_keys, these_values) -> dict:
     """Zip up two lists to make a dict
 
@@ -110,6 +112,7 @@ def data_to_dict(these_keys, these_values) -> dict:
     :return: dictionary
     """
     return dict(zip(these_keys, these_values))
+
 
 def uniprot_make_name_to_id_mapping(dat_gz_file: str) -> dict:
     """Given a Uniprot dat.gz file, like this:

--- a/tests/test_sars_cov_2_gene_annot.py
+++ b/tests/test_sars_cov_2_gene_annot.py
@@ -9,8 +9,8 @@ from kg_covid_19.transform_utils.sars_cov_2_gene_annot.sars_cov_2_gene_annot imp
     _gpi12iterator, _gpa11iterator
 
 
-class TestPharmGKB(TestCase):
-    """Tests the ttd transform"""
+class TestSarsGeneAnnot(TestCase):
+    """Tests the SARS-CoV-2 gene annotation transform"""
 
     def setUp(self) -> None:
         self.sc2ga = SARSCoV2GeneAnnot()
@@ -43,8 +43,13 @@ class TestPharmGKB(TestCase):
         item = next(gpi_iter)
         node = self.sc2ga.gpi_to_gene_node_data(item)
         self.assertEqual(len(self.sc2ga.node_header), len(node))
-        self.assertEqual(node,
-                         ['UniProtKB:P0DTD2', 'Protein 9b', 'biolink:Protein', '', 'NCBITaxon:2697049', 'sars_cov_2_gene_annot'])
+        self.assertEqual(node, ['UniProtKB:P0DTD2',
+                                'P0DTD2',
+                                'biolink:Protein',
+                                'Protein 9b',
+                                '',
+                                'NCBITaxon:2697049',
+                                'sars_cov_2_gene_annot'])
 
     def test_gpa_to_edge_data(self):
         gpa_iter = _gpa11iterator(self.gpa_fh)


### PR DESCRIPTION
`name` in nodes.tsv is now the symbol from GPI, `full_name` is the name from GPI

also fixed a bug in `synonyms` that was emitting just the first character of the synonyms