### PR TITLE
Update merge script to support filters

### DIFF
--- a/kg_covid_19/merge_utils/merge_kg.py
+++ b/kg_covid_19/merge_utils/merge_kg.py
@@ -71,6 +71,16 @@ def load_and_merge(yaml_file: str) -> nx.MultiDiGraph:
             transformers.append(transformer)
         elif target['type'] == 'neo4j':
             transformer = NeoTransformer(None, target['uri'], target['username'],  target['password'])
+            if 'filters' in target:
+                filters = target['filters']
+                node_filters = filters['node_filters'] if 'node_filters' in filters else {}
+                edge_filters = filters['edge_filters'] if 'edge_filters' in filters else {}
+                for k, v in node_filters.items():
+                    transformer.set_node_filter(k, set(v))
+                for k, v in edge_filters.items():
+                    transformer.set_edge_filter(k, set(v))
+                logging.info(f"with node filters: {node_filters}")
+                logging.info(f"with edge filters: {edge_filters}")
             transformer.load()
             transformers.append(transformer)
             transformer.graph.name = key

--- a/merge.yaml
+++ b/merge.yaml
@@ -30,6 +30,13 @@ target:
             edge_label:
                - biolink:interacts_with
                - biolink:has_gene_product
+      operations:
+         - name: kgx.utils.graph_utils.remap_node_identifier
+           args:
+            category: biolink:Protein
+            alternative_property: xrefs
+            prefix: UniProtKB
+
    ttd:
       type: tsv
       filename:

--- a/merge.yaml
+++ b/merge.yaml
@@ -15,6 +15,21 @@ target:
       filename:
          - data/transformed/STRING/nodes.tsv
          - data/transformed/STRING/edges.tsv
+      filters:
+         node_filters:
+            category:
+               - biolink:Gene
+               - biolink:Protein
+         edge_filters:
+            subject_category:
+               - biolink:Gene
+               - biolink:Protein
+            object_category:
+               - biolink:Gene
+               - biolink:Protein
+            edge_label:
+               - biolink:interacts_with
+               - biolink:has_gene_product
    ttd:
       type: tsv
       filename:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+git://github.com/deepakunni3/kgx@kg-covid-19
+git+git://github.com/deepakunni3/kgx


### PR DESCRIPTION
Update merge logic to support filters and operations.

This PR adds support for,
- filtering graphs at the time of merge (currently supports filters for TSVs, and Neo4j)
- applying operations to graphs (like ID remapping)

Filters are applied **before** the graph is loaded.
Operations are applied **after** the graph is loaded.

`merge.yaml` provides a good example of using filters and operations for STRING.
This can be applied to any source.



**Note:** This PR depends on switching KGX to `master`.