### PR TITLE
Fix stats generation to include counts for 'provided_by' property

### DIFF
--- a/kg_covid_19/merge_utils/merge_kg.py
+++ b/kg_covid_19/merge_utils/merge_kg.py
@@ -81,7 +81,7 @@ def load_and_merge(yaml_file: str) -> nx.MultiDiGraph:
     # merge all subgraphs into a single graph
     merged_graph = merge_all_graphs([x.graph for x in transformers])
     merged_graph.name = 'merged_graph'
-    generate_graph_stats(merged_graph, merged_graph.name, f"merged_graph_stats.yaml")
+    generate_graph_stats(merged_graph, merged_graph.name, "merged_graph_stats.yaml", ['provided_by'], ['provided_by'])
 
     # write the merged graph
     if 'destination' in config:


### PR DESCRIPTION
Just a one line fix to ensure that we generate counts by `provided_by` for the summary statistics YAML.