### PR TITLE
Remap synonyms to synonym property in ChemblTransform

### DIFF
--- a/kg_covid_19/transform_utils/chembl/chembl_transform.py
+++ b/kg_covid_19/transform_utils/chembl/chembl_transform.py
@@ -162,6 +162,7 @@ class ChemblTransform(Transform):
         remap = {
             'pref_name': 'name',
             'full_molformula': 'molecular_formula',
+            'synonyms': 'synonym'
         }
         self._node_header.update([remap[x] if x in remap else x for x in allowed_properties])
 


### PR DESCRIPTION
Remap `synonyms` column to `synonym`.
The latter is the appropriate biolink model property.