### PR TITLE
Combine alias and xrefs for STRING

### DIFF
--- a/kg_covid_19/transform_utils/string_ppi/node_header.json
+++ b/kg_covid_19/transform_utils/string_ppi/node_header.json
@@ -3,7 +3,6 @@
     "name",
     "category",
     "description",
-    "alias",
     "xrefs",
     "provided_by"
 ]

--- a/kg_covid_19/transform_utils/string_ppi/string_ppi.py
+++ b/kg_covid_19/transform_utils/string_ppi/string_ppi.py
@@ -187,7 +187,6 @@ class StringTransform(Transform):
                                     'biolink:Gene',
                                     gene_informations['description'],
                                     f"NCBIGene:{self.ensembl2ncbi_map[gene]}",
-                                    "",
                                     self.source_name
                                 ]
                             )
@@ -220,7 +219,6 @@ class StringTransform(Transform):
                             header=self.node_header,
                             data=[f"ENSEMBL:{protein}", "",
                                   protein_node_type,
-                                  "",
                                   "",
                                   uniprot_curie,  # xref
                                   self.source_name]

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -56,8 +56,8 @@ class TestString(TestCase):
         node_file = os.path.join(self.string_output_dir, "nodes.tsv")
         self.assertTrue(os.path.isfile(node_file))
         node_df = pd.read_csv(node_file, sep="\t", header=0)
-        self.assertEqual((10, 7), node_df.shape)
-        self.assertEqual(['id', 'name', 'category', 'description', 'alias', 'xrefs',
+        self.assertEqual((10, 6), node_df.shape)
+        self.assertEqual(['id', 'name', 'category', 'description', 'xrefs',
                           'provided_by'], list(node_df.columns))
         self.assertCountEqual(['ENSEMBL:ENSP00000000233',
                               'ENSEMBL:ENSP00000272298', 'ENSEMBL:ENSP00000253401',


### PR DESCRIPTION
We use both `alias` and `xrefs` in STRING. 
`alias` was chosen back in March but `xrefs` is more semantically appropriate.