### PR TITLE
Type edges as associations

### DIFF
--- a/kg_covid_19/merge_utils/merge_kg.py
+++ b/kg_covid_19/merge_utils/merge_kg.py
@@ -24,6 +24,24 @@ def parse_load_config(yaml_file: str) -> Dict:
         config = yaml.load(YML, Loader=yaml.FullLoader)
     return config
 
+# For NT export, any property that needs to be treated
+# as anything but xsd:string should be defined here.
+PROPERTY_TYPES = {
+    'combined_score': 'xsd:float',
+     "neighborhood": 'xsd:float',
+     "neighborhood_transferred": 'xsd:float',
+     "fusion": 'xsd:float',
+     "cooccurence": 'xsd:float',
+     "homology": 'xsd:float',
+     "coexpression": 'xsd:float',
+     "coexpression_transferred": 'xsd:float',
+     "experiments": 'xsd:float',
+     "experiments_transferred": 'xsd:float',
+     "database": 'xsd:float',
+     "database_transferred": 'xsd:float',
+     "textmining": 'xsd:float',
+     "textmining_transferred": 'xsd:float'
+}
 
 def load_and_merge(yaml_file: str) -> nx.MultiDiGraph:
     """Load and merge sources defined in the config YAML.
@@ -96,6 +114,8 @@ def load_and_merge(yaml_file: str) -> nx.MultiDiGraph:
                 destination_transformer.save()
             elif destination['type'] in get_file_types():
                 destination_transformer = get_transformer(destination['type'])(merged_graph)
+                if destination['type'] in {'nt', 'ttl'}:
+                    destination_transformer.set_property_types(PROPERTY_TYPES)
                 destination_transformer.save(destination['filename'], output_format=destination['type'])
             else:
                 logging.error("type {} not yet supported for KGX load-and-merge operation.".format(destination['type']))

--- a/kg_covid_19/transform_utils/chembl/chembl_transform.py
+++ b/kg_covid_19/transform_utils/chembl/chembl_transform.py
@@ -37,7 +37,7 @@ class ChemblTransform(Transform):
 
         """
         self.node_header = ['id', 'category', 'provided_by']
-        self.edge_header = ['id', 'subject', 'edge_label', 'object', 'relation', 'provided_by']
+        self.edge_header = ['id', 'subject', 'edge_label', 'object', 'relation', 'provided_by', 'type']
 
         # ChEMBL molecules
         data = self.get_chembl_molecules()
@@ -141,6 +141,7 @@ class ChemblTransform(Transform):
             if edge_properties['uo_units']:
                 edge_properties['uo_units'] = edge_properties['uo_units'].replace('_', ':')
             edge_properties['provided_by'] = f"{self.source_name} {self.subset}"
+            edge_properties['type'] = 'biolink:Association'
             edges.append(edge_properties)
         return edges
 

--- a/kg_covid_19/transform_utils/drug_central/drug_central.py
+++ b/kg_covid_19/transform_utils/drug_central/drug_central.py
@@ -50,7 +50,7 @@ class DrugCentralTransform(Transform):
         drug_protein_edge_label = "biolink:molecularly_interacts_with"
         drug_protein_edge_relation = "RO:0002436"  # molecularly interacts with
         self.edge_header = ['subject', 'edge_label', 'object', 'relation',
-                            'provided_by', 'comment']
+                            'provided_by', 'comment', 'type']
 
         with open(self.output_node_file, 'w') as node, \
                 open(self.output_edge_file, 'w') as edge, \
@@ -118,7 +118,8 @@ class DrugCentralTransform(Transform):
                                                protein_id,
                                                drug_protein_edge_relation,
                                                self.source_name,
-                                               items_dict['ACT_COMMENT']])
+                                               items_dict['ACT_COMMENT'],
+                                               'biolink:Association'])
 
         return None
 

--- a/kg_covid_19/transform_utils/intact/intact.py
+++ b/kg_covid_19/transform_utils/intact/intact.py
@@ -59,7 +59,7 @@ class IntAct(Transform):
         self.ppi_edge_label = 'biolink:interacts_with'
         self.ppi_ro_relation = 'RO:0002437'
         self.node_header = ['id', 'name', 'category', 'ncbi_taxid', 'provided_by']
-        self.edge_header = ['subject', 'edge_label', 'object', 'relation', 'provided_by',
+        self.edge_header = ['subject', 'edge_label', 'object', 'relation', 'provided_by', 'type',
                             'publication', 'num_participants', 'association_type',
                             'detection_method',  'subj_exp_role', 'obj_exp_role']
 
@@ -188,10 +188,20 @@ class IntAct(Transform):
                                                                    nodes_dict)
                 if None not in [node1, node2]:
                     edges.append(
-                        [node1, self.ppi_edge_label, node2, self.ppi_ro_relation,
-                         self.source_name, publication, str(len(participants)),
-                         interaction_type_str, detection_method, p1_exp_role,
-                         p2_exp_role])
+                        [
+                            node1,
+                            self.ppi_edge_label, node2,
+                            self.ppi_ro_relation,
+                            self.source_name,
+                            'biolink:Association',
+                            publication,
+                            str(len(participants)),
+                            interaction_type_str,
+                            detection_method,
+                            p1_exp_role,
+                            p2_exp_role
+                        ]
+                    )
 
         return edges
 

--- a/kg_covid_19/transform_utils/pharmgkb/pharmgkb.py
+++ b/kg_covid_19/transform_utils/pharmgkb/pharmgkb.py
@@ -26,7 +26,7 @@ class PharmGKB(Transform):
         source_name = "pharmgkb"
         super().__init__(source_name, input_dir, output_dir)
         self.edge_header = ['subject', 'edge_label', 'object', 'relation',
-                            'provided_by', 'evidence']
+                            'provided_by', 'type', 'evidence']
         self.node_header = ['id', 'name', 'category', 'provided_by']
         self.edge_of_interest = ['Gene',
                                  'Chemical']  # logic also matches 'Chemical'-'Gene'
@@ -205,9 +205,15 @@ class PharmGKB(Transform):
 
         preferred_drug_id = self.make_preferred_drug_id(drug_id, self.drug_id_map)
 
-        data = [preferred_drug_id, self.drug_gene_edge_label,
-                gene_id, self.drug_gene_edge_relation,
-                self.source_name, evidence]
+        data = [
+            preferred_drug_id,
+            self.drug_gene_edge_label,
+            gene_id,
+            self.drug_gene_edge_relation,
+            self.source_name,
+            'biolink:Association',
+            evidence
+        ]
 
         write_node_edge_item(fh=fh,
                              header=self.edge_header,

--- a/kg_covid_19/transform_utils/sars_cov_2_gene_annot/sars_cov_2_gene_annot.py
+++ b/kg_covid_19/transform_utils/sars_cov_2_gene_annot/sars_cov_2_gene_annot.py
@@ -24,7 +24,7 @@ class SARSCoV2GeneAnnot(Transform):
         self.node_header = ['id', 'name', 'category', 'full_name', 'synonym',
                             'in_taxon', 'xrefs', 'provided_by']
         self.edge_header = ['subject', 'edge_label', 'object', 'relation',
-                            'provided_by', 'DB_References', 'ECO_code', 'With',
+                            'provided_by', 'type', 'DB_References', 'ECO_code', 'With',
                             'Interacting_taxon_ID',
                             'Date', 'Assigned_by', 'Annotation_Extension',
                             'Annotation_Properties']
@@ -91,8 +91,15 @@ class SARSCoV2GeneAnnot(Transform):
         except KeyError:
             relation = ''
 
-        edge_data = [subj, self.edge_label_prefix + edge_label, obj, relation,
-                     self.source_name]
+        edge_data = [
+            subj,
+            self.edge_label_prefix + edge_label,
+            obj,
+            relation,
+            self.source_name,
+            'biolink:Association'
+        ]
+
         # all the others
         for key in ['DB:Reference', 'ECO_Evidence_code', 'With', 'Interacting_taxon_ID',
                     'Date', 'Assigned_by', 'Annotation_Extension',

--- a/kg_covid_19/transform_utils/scibite_cord/scibite_cord.py
+++ b/kg_covid_19/transform_utils/scibite_cord/scibite_cord.py
@@ -59,7 +59,7 @@ class ScibiteCordTransform(Transform):
             data_files.extend(data_files)
 
         self.node_header = ['id', 'name', 'category', 'description', 'provided_by']
-        self.edge_header = ['subject', 'edge_label', 'object', 'relation', 'provided_by']
+        self.edge_header = ['subject', 'edge_label', 'object', 'relation', 'provided_by', 'type']
         node_handle = open(self.output_node_file, 'w')
         edge_handle = open(self.output_edge_file, 'w')
         node_handle.write("\t".join(self.node_header) + "\n")
@@ -190,7 +190,8 @@ class ScibiteCordTransform(Transform):
                     f"biolink:related_to",
                     f"CORD:{paper_id}",
                     "SIO:000255",
-                    provided_by
+                    provided_by,
+                    "biolink:Association"
                 ]
             )
 
@@ -290,7 +291,8 @@ class ScibiteCordTransform(Transform):
                                 "biolink:correlated_with",
                                 f"{paper_curie}",
                                 f"RO:0002610", # 'correlated with'
-                                f"{self.source_name} co-occurrences"
+                                f"{self.source_name} co-occurrences",
+                                "biolink:Association"
                             ]
                         )
                         self.seen.add((curie, paper_curie))

--- a/kg_covid_19/transform_utils/string_ppi/edge_core_header.json
+++ b/kg_covid_19/transform_utils/string_ppi/edge_core_header.json
@@ -4,5 +4,6 @@
     "object",
     "relation",
     "provided_by",
+    "type",
     "combined_score"
 ]

--- a/kg_covid_19/transform_utils/string_ppi/string_ppi.py
+++ b/kg_covid_19/transform_utils/string_ppi/string_ppi.py
@@ -199,6 +199,7 @@ class StringTransform(Transform):
                                     f"ENSEMBL:{protein}",
                                     "RO:0002205",
                                     "NCBI",
+                                    ""
                                 ] + self.extra_header
                             )
 
@@ -221,7 +222,8 @@ class StringTransform(Transform):
                                   protein_node_type,
                                   "",
                                   uniprot_curie,  # xref
-                                  self.source_name]
+                                  self.source_name
+                                  ]
                         )
 
 
@@ -229,11 +231,15 @@ class StringTransform(Transform):
                 write_node_edge_item(
                     fh=edge,
                     header=self.edge_header,
-                    data=[f"ENSEMBL:{proteins[0]}", edge_label, f"ENSEMBL:{proteins[1]}",
-                          relation, "STRING", items_dict['combined_score']] + [
-                        items_dict.get(header, "")
-                        for header in edge_additional_headers
-                    ]
+                    data=[
+                             f"ENSEMBL:{proteins[0]}",
+                             edge_label,
+                             f"ENSEMBL:{proteins[1]}",
+                             relation,
+                             "STRING",
+                             "biolink:Association",
+                             items_dict['combined_score']
+                         ] + [items_dict.get(header, "") for header in edge_additional_headers]
                 )
 
 

--- a/kg_covid_19/transform_utils/ttd/ttd.py
+++ b/kg_covid_19/transform_utils/ttd/ttd.py
@@ -41,7 +41,7 @@ class TTDTransform(Transform):
         uniprot_curie_prefix = "UniProtKB:"
         self.node_header = ['id', 'name', 'category', 'TTD_ID', 'provided_by']
         self.edge_header = ['subject', 'edge_label', 'object', 'relation',
-                            'provided_by', 'target_type']
+                            'provided_by', 'type', 'target_type']
 
         # make name to id map for uniprot names of human proteins
         dat_gz_id_file = os.path.join(self.input_base_dir,
@@ -110,6 +110,7 @@ class TTDTransform(Transform):
                                                    this_id,
                                                    drug_gene_edge_relation,
                                                    self.source_name,
+                                                   'biolink:Association',
                                                    targ_type])
 
     def get_uniproids(self, data: dict, name_2_id_map: dict,

--- a/kg_covid_19/transform_utils/zhou_host_proteins/zhou_transform.py
+++ b/kg_covid_19/transform_utils/zhou_host_proteins/zhou_transform.py
@@ -36,7 +36,7 @@ class ZhouTransform(Transform):
         super().__init__(source_name, input_dir, output_dir)
         self.node_header = ['id', 'name', 'category', 'provided_by']
         self.edge_header = ['subject', 'edge_label', 'object', 'relation',
-                            'provided_by', 'publication']
+                            'provided_by', 'type', 'publication']
 
     def run(self, data_file: Optional[str] = None):
         """Method is called and performs needed transformations to process the zhou host protein data, additional
@@ -116,6 +116,7 @@ class ZhouTransform(Transform):
                                          corona_curie,
                                          host_gene_vgene_relation,
                                          self.source_name,
+                                         'biolink:Association',
                                          pubmed_curie_prefix + row['PubMed ID']
                                      ])
 

--- a/tests/test_drug_central.py
+++ b/tests/test_drug_central.py
@@ -84,7 +84,8 @@ class TestDrugCentral(unittest.TestCase):
         edge_file = os.path.join(self.dc_output_dir, "edges.tsv")
         self.assertTrue(os.path.isfile(edge_file))
         edge_df = pd.read_csv(edge_file, sep="\t", header=0)
-        self.assertEqual((21, 6), edge_df.shape)
-        self.assertEqual(['subject', 'edge_label', 'object', 'relation', 'provided_by',
-                          'comment'],
-                         list(edge_df.columns))
+        self.assertEqual((21, 7), edge_df.shape)
+        self.assertEqual(
+            ['subject', 'edge_label', 'object', 'relation', 'provided_by', 'comment', 'type'],
+             list(edge_df.columns)
+        )

--- a/tests/test_intact.py
+++ b/tests/test_intact.py
@@ -15,7 +15,7 @@ class TestIntAct(unittest.TestCase):
         self.assertEqual(self.intact.node_header,
                          ['id', 'name', 'category', 'ncbi_taxid', 'provided_by'])
         self.assertEqual(self.intact.edge_header,
-                        ['subject', 'edge_label', 'object', 'relation', 'provided_by',
+                        ['subject', 'edge_label', 'object', 'relation', 'provided_by', 'type',
                          'publication', 'num_participants', 'association_type',
                          'detection_method', 'subj_exp_role', 'obj_exp_role'])
 
@@ -35,7 +35,7 @@ class TestIntAct(unittest.TestCase):
                     ['UniProtKB:P0C6X7-PRO_0000037317', 'nsp10_cvhsa', 'biolink:RNA',
                      '694009', 'intact']],
           'edges': [['UniProtKB:P20290', 'biolink:interacts_with',
-                     'UniProtKB:P0C6X7-PRO_0000037317', 'RO:0002437', 'intact',
+                     'UniProtKB:P0C6X7-PRO_0000037317', 'RO:0002437', 'intact', 'biolink:Association',
                      'PMID:16157265', '2', 'physical association', '2 hybrid', 'prey',
                      'bait']]
          }),
@@ -47,6 +47,7 @@ class TestIntAct(unittest.TestCase):
                 'UniProtKB:P41811',
                 'RO:0002437',
                 'intact',
+                'biolink:Association',
                 'PMID:23481256',
                 '3',
                 'physical association',

--- a/tests/test_sars_cov_2_gene_annot.py
+++ b/tests/test_sars_cov_2_gene_annot.py
@@ -61,7 +61,7 @@ class TestSarsGeneAnnot(TestCase):
         self.assertEqual(len(self.sc2ga.edge_header), len(edge1))
         self.assertEqual(edge1,
                          ['UniProtKB:P0DTC1', 'biolink:enables', 'GO:0003723',
-                          'RO:0002327', 'sars_cov_2_gene_annot',
+                          'RO:0002327', 'sars_cov_2_gene_annot', 'biolink:Association',
                           'GO_REF:0000043', 'ECO:0000322', 'UniProtKB-KW:KW-0694', '',
                           '20200321', 'UniProt', '', 'go_evidence=IEA'])
 

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -75,8 +75,8 @@ class TestString(TestCase):
         edge_file = os.path.join(self.string_output_dir, "edges.tsv")
         self.assertTrue(os.path.isfile(edge_file))
         edge_df = pd.read_csv(edge_file, sep="\t", header=0)
-        self.assertEqual((9, 19), edge_df.shape)
-        self.assertEqual(['subject', 'edge_label', 'object', 'relation', 'provided_by',
+        self.assertEqual((9, 20), edge_df.shape)
+        self.assertEqual(['subject', 'edge_label', 'object', 'relation', 'provided_by', 'type',
                           'combined_score', 'neighborhood', 'neighborhood_transferred',
                           'fusion', 'cooccurence', 'homology', 'coexpression',
                           'coexpression_transferred', 'experiments',


### PR DESCRIPTION
This PR,
- types edges as `biolink:Association`. This is now required by KGX to reify an edge when exporting as RDF
- also specifies the type for certain properties. This ensure that the value of these properties are treated properly when exporting RDF 