### PR TITLE
Add versioning of builds to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,11 +133,11 @@ pipeline {
 			// make sure we aren't going to clobber existing data
     		        withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG')]) {
 		                REMOTE_BUILD_DIR_CONTENTS = sh (
-		    	   	    script: 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate ls s3://kg-hub-public-data/$BUILDSTARTDATE/',
+		    	   	    script: 's3cmd -c $S3CMD_CFG ls s3://kg-hub-public-data/$BUILDSTARTDATE/',
 		    	   	    returnStdout: true
 		                ).trim()
 		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): '${REMOTE_BUILD_DIR_CONTENTS}'"
-				if('$BUILDSTARTDATE'){
+				if($REMOTE_BUILD_DIR_CONTENTS){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
                         		sh 'exit 1'
 				} else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,7 +142,7 @@ pipeline {
 		    	   	    script: 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate ls s3://kg-hub-public-data/$BUILDSTARTDATE/',
 		    	   	    returnStdout: true
 		                ).trim()
-		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): ${REMOTE_BUILD_DIR_CONTENTS}"
+		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): '${REMOTE_BUILD_DIR_CONTENTS}'"
 				if('$BUILDSTARTDATE'.trim() != ''){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
                         		sh 'exit 1'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -189,7 +189,7 @@ pipeline {
 
 			        // make current/ directory
 				sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory current --prefix https://kg-hub.berkeleybop.io/current -x -u'
-				sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE/ s3://kg-hub-public-data/new_current'
+				sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE/ s3://kg-hub-public-data/new_current/'
 
                                 //
                                 // make $BUILDSTARTDATE the new current/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,8 +62,9 @@ pipeline {
                 dir('./gitrepo') {
                     script {
                         def run_py_dl = sh(
-                            script: '. venv/bin/activate && python3.7 run.py download', returnStatus: true
-                        )
+                            // script: '. venv/bin/activate && python3.7 run.py download', returnStatus: true
+                            script: 'BADCOMMAND', returnStatus: true
+			)
                         if (run_py_dl == 0) {
                             if (env.BRANCH_NAME != 'master') { // upload raw to s3 if we're on correct branch
                                 echo "Will not push if not on correct branch."

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,18 +172,18 @@ pipeline {
                                 sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/current -x -u'
                                 sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE/ s3://kg-hub-public-data/current/'
 
-                        	// Build the top level index.html
-				// "External" packages required to run these
-				// scripts.
-				sh './venv/bin/pip install pystache boto3'
-				sh '. venv/bin/activate && python3.7 ./go-site/scripts/bucket-indexer.py --credentials $AWS_JSON --bucket kg-hub-public-data --inject ./go-site/scripts/directory-index-template.html --prefix https://kg-hub.berkeleybop.io/ > top-level-index.html'
-				sh 's3cmd -c $S3CMD_CFG put --acl-public --mime-type=text/html --cf-invalidate top-level-index.html s3://kg-hub-public-data/index.html'
+                                // Build the top level index.html
+                                // "External" packages required to run these
+                                // scripts.
+                                sh './venv/bin/pip install pystache boto3'
+                                sh '. venv/bin/activate && python3.7 ./go-site/scripts/bucket-indexer.py --credentials $AWS_JSON --bucket kg-hub-public-data --inject ./go-site/scripts/directory-index-template.html --prefix https://kg-hub.berkeleybop.io/ > top-level-index.html'
+                                sh 's3cmd -c $S3CMD_CFG put --acl-public --mime-type=text/html --cf-invalidate top-level-index.html s3://kg-hub-public-data/index.html'
 
-				// Invalidate the CDN now that the new
-				// files are up.
-				sh './venv/bin/pip install awscli'
-				sh 'echo "[preview]" > ./awscli_config.txt && echo "cloudfront=true" >> ./awscli_config.txt'
-				sh '. venv/bin/activate && AWS_CONFIG_FILE=./awscli_config.txt python3.7 ./venv/bin/aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_DISTRIBUTION_ID --paths "/*"'
+                                // Invalidate the CDN now that the new
+                                // files are up.
+                                sh './venv/bin/pip install awscli'
+                                sh 'echo "[preview]" > ./awscli_config.txt && echo "cloudfront=true" >> ./awscli_config.txt'
+                                sh '. venv/bin/activate && AWS_CONFIG_FILE=./awscli_config.txt python3.7 ./venv/bin/aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_DISTRIBUTION_ID --paths "/*"'
 
                                 // Should now appear at:
                                 // https://kg-hub.berkeleybop.io/[artifact name]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,9 +59,8 @@ pipeline {
                 dir('./gitrepo') {
                     script {
                         def run_py_dl = sh(
-                            // script: '. venv/bin/activate && python3.7 run.py download', returnStatus: true
-                            script: 'BADCOMMAND', returnStatus: true
-			)
+                            script: '. venv/bin/activate && python3.7 run.py download', returnStatus: true
+                        )
                         if (run_py_dl == 0) {
                             if (env.BRANCH_NAME != 'master') { // upload raw to s3 if we're on correct branch
                                 echo "Will not push if not on correct branch."

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,7 +166,7 @@ pipeline {
                                 //
                                 // put $BUILDSTARTDATE/ in s3 bucket
                                 //
-			        sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/ -x'
+			        sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE/ --prefix https://kg-hub.berkeleybop.io/ -x'
 			        sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate put -pr $BUILDSTARTDATE s3://kg-hub-public-data/'
 
                                 //

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,7 +161,9 @@ pipeline {
                         } else {
                             withCredentials([
 					    file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG'),
-					    file(credentialsId: 'aws_kg_hub_push_json', variable: 'AWS_JSON')
+					    file(credentialsId: 'aws_kg_hub_push_json', variable: 'AWS_JSON'),
+					    string(credentialsId: 'aws_kg_hub_access_key', variable: 'AWS_ACCESS_KEY_ID'), 
+					    string(credentialsId: 'aws_kg_hub_secret_key', variable: 'AWS_SECRET_ACCESS_KEY')]) {
 				    ]) {
                                 //
                                 // make $BUILDSTARTDATE/ directory and sync to s3 bucket

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,6 +143,12 @@ pipeline {
 		    	   	    returnStdout: true
 		                ).trim()
 		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): ${REMOTE_BUILD_DIR_CONTENTS}"
+				if($REMOTE_BUILD_DIR_CONTENTS){
+                        		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
+                        		// sh 'exit 1'
+				} else {
+                        		echo "remote directory $BUILDSTARTDATE is empty, proceeding"
+				}
 			}
 
 		        sh 'git clone https://github.com/justaddcoffee/go-site.git'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,7 +182,7 @@ pipeline {
 				// scripts.
 				sh './venv/bin/pip install pystache boto3'
 				sh '. venv/bin/activate && python3.7 ./go-site/scripts/bucket-indexer.py --credentials $AWS_JSON --bucket kg-hub-public-data --inject ./go-site/scripts/directory-index-template.html --prefix https://kg-hub.berkeleybop.io/ > top-level-index.html'
-				sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate cp top-level-index.html s3://kg-hub-public-data/index.html'
+				sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate put top-level-index.html s3://kg-hub-public-data/index.html'
 
                                 // Should now appear at:
                                 // https://kg-hub.berkeleybop.io/[artifact name]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
 	// upload already has an invalidation on it. For current,
 	// snapshot, and experimental.
 	AWS_CLOUDFRONT_DISTRIBUTION_ID = 'EUVSWXZQBXCFP'
-	AWS_CLOUDFRONT_RELEASE_DISTRIBUTION_ID = 'EUVSWXZQBXCFP'	    
     }
 
     options {
@@ -205,12 +204,7 @@ pipeline {
 				// files are up.
 				sh './venv/bin/pip install awscli'
 				sh 'echo "[preview]" > ./awscli_config.txt && echo "cloudfront=true" >> ./awscli_config.txt'
-				sh 'AWS_CONFIG_FILE=./awscli_config.txt python3.7 ./venv/bin/aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_DISTRIBUTION_ID --paths "/*"'
-				// The release branch also needs to
-				// deal with the second location.
-				if( env.BRANCH_NAME == 'release' ){
-				    sh 'AWS_CONFIG_FILE=./awscli_config.txt python3.7 ./venv/bin/aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_RELEASE_DISTRIBUTION_ID --paths "/*"'
-				}
+				sh '. venv/bin/activate && AWS_CONFIG_FILE=./awscli_config.txt python3.7 ./venv/bin/aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_DISTRIBUTION_ID --paths "/*"'
 
                                 // Should now appear at:
                                 // https://kg-hub.berkeleybop.io/[artifact name]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,7 @@ pipeline {
                 // code for building s3 index files
                 dir('./gitrepo') {
                     script {
-		        if(fileExists($BUILDSTARTDATE)){
+		        if(fileExists('$BUILDSTARTDATE')){
                         	echo "Will not overwrite existing directory: $BUILDSTARTDATE"
                         	sh 'exit 1'
 			} else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -191,9 +191,9 @@ pipeline {
                                 // make $BUILDSTARTDATE the new current/
                                 // 	    
 				// The following cp always times out:
-                                // sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate cp -v -pr s3://kg-hub-public-data/$BUILDSTARTDATE/ s3://kg-hub-public-data/new_current/'
-                                // sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate rm -fr s3://kg-hub-public-data/current'
-                                // sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate mv --recursive s3://kg-hub-public-data/new_current s3://kg-hub-public-data/current'
+                                sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate cp -v -pr s3://kg-hub-public-data/$BUILDSTARTDATE/ s3://kg-hub-public-data/new_current/'
+                                sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate rm -fr s3://kg-hub-public-data/current'
+                                sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate mv --recursive s3://kg-hub-public-data/new_current s3://kg-hub-public-data/current'
 
                         	// Build the top level index.html
 				// "External" packages required to run these

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,6 +130,7 @@ pipeline {
                 // code for building s3 index files
                 dir('./gitrepo') {
                     script {
+			// make sure we aren't going to clobber existing data
 		        if(fileExists('$BUILDSTARTDATE')){
                         	echo "Will not overwrite existing directory: $BUILDSTARTDATE"
                         	sh 'exit 1'
@@ -141,8 +142,14 @@ pipeline {
 		    	   	    script: 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate ls s3://kg-hub-public-data/$BUILDSTARTDATE/',
 		    	   	    returnStdout: true
 		                ).trim()
-		                echo "REMOTE_BUILD_DIR_CONTENTS: ${REMOTE_BUILD_DIR_CONTENTS}"			    
+		                echo "REMOTE_BUILD_DIR_CONTENTS: ${REMOTE_BUILD_DIR_CONTENTS}"
+				if($REMOTE_BUILD_DIR_CONTENTS){
+                        		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
+                        		sh 'exit 1'
+				}
 			}
+			    
+			
 		        sh 'git clone https://github.com/justaddcoffee/go-site.git'
 
                         // if (env.BRANCH_NAME != 'master' ||

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ pipeline {
 		    	   	    returnStdout: true
 		                ).trim()
 		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): '${REMOTE_BUILD_DIR_CONTENTS}'"
-				if("${BUILDSTARTDATE}".trim() != ''){
+				if("${BUILDSTARTDATE}"?.trim() != ''){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
                         		sh 'exit 1'
 				} else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,8 +184,8 @@ pipeline {
                                 //
                                 // put $BUILDSTARTDATE/ in s3 bucket
                                 //
-			        sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/$BUILDSTARTDATE -x'
-			        sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE s3://kg-hub-public-data/'
+			        sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/$BUILDSTARTDATE -x -u'
+				sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE s3://kg-hub-public-data/'
 
                                 //
                                 // make $BUILDSTARTDATE the new current/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,8 +138,7 @@ pipeline {
 				            }
 			            }
 
-                        // if (env.BRANCH_NAME != 'master' ||
-                        if (env.BRANCH_NAME == 'NOT THIS BRANCH') {
+                        if (env.BRANCH_NAME != 'master') {
                             echo "Will not push if not on correct branch."
                         } else {
                             withCredentials([

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,12 +131,6 @@ pipeline {
                 dir('./gitrepo') {
                     script {
 			// make sure we aren't going to clobber existing data
-		        if(fileExists('$BUILDSTARTDATE')){
-                        	echo "Will not overwrite existing directory: $BUILDSTARTDATE"
-                        	sh 'exit 1'
-			} else {
-                        	echo "local directory $BUILDSTARTDATE doesn't exist, proceeding"
-			}
     		        withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG')]) {
 		                REMOTE_BUILD_DIR_CONTENTS = sh (
 		    	   	    script: 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate ls s3://kg-hub-public-data/$BUILDSTARTDATE/',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,7 +182,7 @@ pipeline {
 				// scripts.
 				sh './venv/bin/pip install pystache boto3'
 				sh '. venv/bin/activate && python3.7 ./go-site/scripts/bucket-indexer.py --credentials $AWS_JSON --bucket kg-hub-public-data --inject ./go-site/scripts/directory-index-template.html --prefix https://kg-hub.berkeleybop.io/ > top-level-index.html'
-				sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate put top-level-index.html s3://kg-hub-public-data/index.html'
+				sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate --cf-invalidate-default-index put top-level-index.html s3://kg-hub-public-data/index.html'
 
                                 // Should now appear at:
                                 // https://kg-hub.berkeleybop.io/[artifact name]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ pipeline {
 		    	   	    returnStdout: true
 		                ).trim()
 		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): '${REMOTE_BUILD_DIR_CONTENTS}'"
-				if('$BUILDSTARTDATE'.trim() != ''){
+				if("${BUILDSTARTDATE}".trim() != ''){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
                         		sh 'exit 1'
 				} else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,6 +130,8 @@ pipeline {
                 // code for building s3 index files
                 dir('./gitrepo') {
                     script {
+			sh 'git clone https://github.com/justaddcoffee/go-site.git'
+
 			// make sure we aren't going to clobber existing data
     		        withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG')]) {
 		                REMOTE_BUILD_DIR_CONTENTS = sh (
@@ -137,15 +139,13 @@ pipeline {
 		    	   	    returnStdout: true
 		                ).trim()
 		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): '${REMOTE_BUILD_DIR_CONTENTS}'"
-				if($REMOTE_BUILD_DIR_CONTENTS != ''){
+				if('$REMOTE_BUILD_DIR_CONTENTS' != ''){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
                         		sh 'exit 1'
 				} else {
                         		echo "remote directory $BUILDSTARTDATE is empty, proceeding"
 				}
 			}
-
-		        sh 'git clone https://github.com/justaddcoffee/go-site.git'
 
                         // if (env.BRANCH_NAME != 'master' ||
                         if (env.BRANCH_NAME == 'NOT THIS BRANCH') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -203,6 +203,7 @@ pipeline {
 
 				// Invalidate the CDN now that the new
 				// files are up.
+				sh './venv/bin/pip install awscli'
 				sh 'echo "[preview]" > ./awscli_config.txt && echo "cloudfront=true" >> ./awscli_config.txt'
 				sh 'AWS_CONFIG_FILE=./awscli_config.txt python3.7 ./venv/bin/aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_DISTRIBUTION_ID --paths "/*"'
 				// The release branch also needs to

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ pipeline {
 		    	   	    returnStdout: true
 		                ).trim()
 		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): ${REMOTE_BUILD_DIR_CONTENTS}"
-				if("" == ""){
+				if('$BUILDSTARTDATE'){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
                         		// sh 'exit 1'
 				} else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,21 +101,21 @@ pipeline {
             }
         }
 
-//         stage('Make blazegraph journal'){
-//             steps {
-//                 dir('./gitrepo/blazegraph') {
-//                         git(
-//                                 url: 'https://github.com/balhoff/blazegraph-runner.git',
-//                                 branch: 'master'
-//                         )
-//                         sh 'sbt stage'
-//                         sh 'pigz -d ../data/merged/merged-kg.nt.gz'
-//                         sh 'export JAVA_OPTS=-Xmx128G && ./target/universal/stage/bin/blazegraph-runner load --informat=ntriples --journal=../merged-kg.jnl --use-ontology-graph=true ../data/merged/merged-kg.nt'
-//                         sh 'pigz ../merged-kg.jnl'
-//                         sh 'pigz ../data/merged/merged-kg.nt'
-//                 }
-//             }
-//         }
+        stage('Make blazegraph journal'){
+            steps {
+                dir('./gitrepo/blazegraph') {
+                        git(
+                                url: 'https://github.com/balhoff/blazegraph-runner.git',
+                                branch: 'master'
+                        )
+                        sh 'sbt stage'
+                        sh 'pigz -d ../data/merged/merged-kg.nt.gz'
+                        sh 'export JAVA_OPTS=-Xmx128G && ./target/universal/stage/bin/blazegraph-runner load --informat=ntriples --journal=../merged-kg.jnl --use-ontology-graph=true ../data/merged/merged-kg.nt'
+                        sh 'pigz ../merged-kg.jnl'
+                        sh 'pigz ../data/merged/merged-kg.nt'
+                }
+            }
+        }
 
         stage('Publish') {
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ pipeline {
 		    	   	    returnStdout: true
 		                ).trim()
 		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): ${REMOTE_BUILD_DIR_CONTENTS}"
-				if($REMOTE_BUILD_DIR_CONTENTS){
+				if("" == ""){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
                         		// sh 'exit 1'
 				} else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ pipeline {
 		    	   	    returnStdout: true
 		                ).trim()
 		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): ${REMOTE_BUILD_DIR_CONTENTS}"
-				if('$BUILDSTARTDATE' != ''){
+				if('$BUILDSTARTDATE'.trim() != ''){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
                         		sh 'exit 1'
 				} else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,13 +187,17 @@ pipeline {
 			        sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/$BUILDSTARTDATE -x -u'
 				sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE s3://kg-hub-public-data/'
 
+			        // make current/ directory
+				sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory current --prefix https://kg-hub.berkeleybop.io/current -x -u'
+				sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE/ s3://kg-hub-public-data/new_current'
+
                                 //
                                 // make $BUILDSTARTDATE the new current/
                                 // 	    
 				// The following cp always times out:
-                                sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate cp -v -pr s3://kg-hub-public-data/$BUILDSTARTDATE/ s3://kg-hub-public-data/new_current/'
-                                sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate rm -fr s3://kg-hub-public-data/current'
-                                sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate mv --recursive s3://kg-hub-public-data/new_current/ s3://kg-hub-public-data/current/'
+                                // sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate cp -v -pr s3://kg-hub-public-data/$BUILDSTARTDATE/ s3://kg-hub-public-data/new_current/'
+                                // sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate rm -fr s3://kg-hub-public-data/current'
+                                // sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate mv --recursive s3://kg-hub-public-data/new_current/ s3://kg-hub-public-data/current/'
 
                         	// Build the top level index.html
 				// "External" packages required to run these

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,11 +73,8 @@ pipeline {
                             withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG')]) {
                                 sh 'rm -fr data/raw || true;'
                                 sh 'mkdir -p data/raw || true'
-			        // FIX THIS
-                                // sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=plain/text get -r s3://kg-hub-public-data/raw/ data/raw/'
-			 	sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=plain/text get -r s3://kg-hub-public-data/raw/hp.json data/raw/hp.json'
-
-			    }
+                                sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=plain/text get -r s3://kg-hub-public-data/raw/ data/raw/'
+                            }
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         BUILDSTARTDATE = sh(script: "echo `date +%Y%m%d`", returnStdout: true).trim()
 
         // Distribution ID for the AWS CloudFront for this branch,
-        // used soley for invalidations
+        // used solely for invalidations
         AWS_CLOUDFRONT_DISTRIBUTION_ID = 'EUVSWXZQBXCFP'
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,7 +176,7 @@ pipeline {
                                 // put $BUILDSTARTDATE/ in s3 bucket
                                 //
 			        sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/ -x'
-			        sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate put -pr $BUILDSTARTDATE s3://kg-hub-public-data/'
+			        sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE s3://kg-hub-public-data/'
 
                                 //
                                 // make $BUILDSTARTDATE the new current/
@@ -191,7 +191,7 @@ pipeline {
 				// scripts.
 				sh './venv/bin/pip install pystache boto3'
 				sh '. venv/bin/activate && python3.7 ./go-site/scripts/bucket-indexer.py --credentials $AWS_JSON --bucket kg-hub-public-data --inject ./go-site/scripts/directory-index-template.html --prefix https://kg-hub.berkeleybop.io/ > top-level-index.html'
-				sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate put top-level-index.html s3://kg-hub-public-data/index.html'
+				sh 's3cmd -c $S3CMD_CFG put --acl-public --mime-type=text/html --cf-invalidate top-level-index.html s3://kg-hub-public-data/index.html'
 
                                 // Should now appear at:
                                 // https://kg-hub.berkeleybop.io/[artifact name]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ pipeline {
 		    	   	    returnStdout: true
 		                ).trim()
 		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): '${REMOTE_BUILD_DIR_CONTENTS}'"
-				if("${BUILDSTARTDATE}"?.trim() != ''){
+				if('$BUILDSTARTDATE'){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
                         		sh 'exit 1'
 				} else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ pipeline {
 		    	   	    returnStdout: true
 		                ).trim()
 		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): ${REMOTE_BUILD_DIR_CONTENTS}"
-				if('$BUILDSTARTDATE'){
+				if('$BUILDSTARTDATE' != ''){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
                         		sh 'exit 1'
 				} else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -193,7 +193,7 @@ pipeline {
 				// The following cp always times out:
                                 sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate cp -v -pr s3://kg-hub-public-data/$BUILDSTARTDATE/ s3://kg-hub-public-data/new_current/'
                                 sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate rm -fr s3://kg-hub-public-data/current'
-                                sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate mv --recursive s3://kg-hub-public-data/new_current s3://kg-hub-public-data/current/'
+                                sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate mv --recursive s3://kg-hub-public-data/new_current/ s3://kg-hub-public-data/current/'
 
                         	// Build the top level index.html
 				// "External" packages required to run these

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -165,12 +165,12 @@ pipeline {
                                 //
                                 // put $BUILDSTARTDATE/ in s3 bucket
                                 //
-			        sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/$BUILDSTARTDATE -x -u'
-				sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE s3://kg-hub-public-data/'
+                                sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/$BUILDSTARTDATE -x -u'
+                                sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE s3://kg-hub-public-data/'
 
-			        // make current/ directory
-				sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/current -x -u'
-				sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE/ s3://kg-hub-public-data/current/'
+                                // make current/ directory
+                                sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/current -x -u'
+                                sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE/ s3://kg-hub-public-data/current/'
 
                                 //
                                 // make $BUILDSTARTDATE the new current/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -159,10 +159,10 @@ pipeline {
                                 // make $BUILDSTARTDATE/ directory and sync to s3 bucket
                                 //
                                 sh 'mkdir $BUILDSTARTDATE/'
-                                sh 'cp -p data/merged/merged-kg.nt.gz $BUILDSTARTDATE/'
-                                sh 'cp -p data/merged/merged-kg.tar.gz $BUILDSTARTDATE/'
+                                sh 'cp -p data/merged/merged-kg.nt.gz $BUILDSTARTDATE/kg-covid-19.nt.gz'
+                                sh 'cp -p data/merged/merged-kg.tar.gz $BUILDSTARTDATE/kg-covid-19.tar.gz'
                                 sh 'touch merged-kg.jnl.gz' // REMOVE
-                                sh 'cp -p merged-kg.jnl.gz $BUILDSTARTDATE/'
+                                sh 'cp -p merged-kg.jnl.gz $BUILDSTARTDATE/kg-covid-19.jnl.gz'
                                 // transformed data
                                 sh 'rm -fr data/transformed/.gitkeep'
                                 sh 'cp -pr data/transformed $BUILDSTARTDATE/'
@@ -176,7 +176,7 @@ pipeline {
                                 // put $BUILDSTARTDATE/ in s3 bucket
                                 //
 			        sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/ -x'
-			        sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE s3://kg-hub-public-data/'
+			        sh 's3cmd -c $S3CMD_CFG put -pr --cf-default-root-object=$BUILDSTARTDATE --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE s3://kg-hub-public-data/'
 
                                 //
                                 // make $BUILDSTARTDATE the new current/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
         stage('Ready and clean') {
             steps {
                 // Give us a minute to cancel if we want.
-                // sleep time: 1, unit: 'MINUTES'
+                sleep time: 1, unit: 'MINUTES'
                 cleanWs()
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,7 +184,7 @@ pipeline {
                                 //
                                 // put $BUILDSTARTDATE/ in s3 bucket
                                 //
-			        sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/ -x'
+			        sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/$BUILDSTARTDATE -x'
 			        sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE s3://kg-hub-public-data/'
 
                                 //

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,7 +166,7 @@ pipeline {
                                 //
                                 // put $BUILDSTARTDATE/ in s3 bucket
                                 //
-			        sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE/ --prefix https://kg-hub.berkeleybop.io/ -x'
+			        sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/ -x'
 			        sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate put -pr $BUILDSTARTDATE s3://kg-hub-public-data/'
 
                                 //

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,7 @@ pipeline {
                 // code for building s3 index files
                 dir('./gitrepo') {
                     script {
-		        if(fileExists('./gitrepo/$BUILDSTARTDATE')){
+		        if(fileExists($BUILDSTARTDATE)){
                         	echo "Will not overwrite existing directory: $BUILDSTARTDATE"
                         	sh 'exit 1'
 			} else {
@@ -182,7 +182,7 @@ pipeline {
 				// scripts.
 				sh './venv/bin/pip install pystache boto3'
 				sh '. venv/bin/activate && python3.7 ./go-site/scripts/bucket-indexer.py --credentials $AWS_JSON --bucket kg-hub-public-data --inject ./go-site/scripts/directory-index-template.html --prefix https://kg-hub.berkeleybop.io/ > top-level-index.html'
-				sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate --cf-invalidate-default-index put top-level-index.html s3://kg-hub-public-data/index.html'
+				sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate put top-level-index.html s3://kg-hub-public-data/index.html'
 
                                 // Should now appear at:
                                 // https://kg-hub.berkeleybop.io/[artifact name]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,7 +182,7 @@ pipeline {
 				// scripts.
 				sh './venv/bin/pip install pystache boto3'
 				sh '. venv/bin/activate && python3.7 ./go-site/scripts/bucket-indexer.py --credentials $AWS_JSON --bucket kg-hub-public-data --inject ./go-site/scripts/directory-index-template.html --prefix https://kg-hub.berkeleybop.io/ > top-level-index.html'
-				sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate put top-level-index.html s3://kg-hub-public-data/index.html'
+				sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate sync top-level-index.html s3://kg-hub-public-data/index.html'
 
                                 // Should now appear at:
                                 // https://kg-hub.berkeleybop.io/[artifact name]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,7 +139,7 @@ pipeline {
 		    	   	    returnStdout: true
 		                ).trim()
 		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): '${REMOTE_BUILD_DIR_CONTENTS}'"
-				if('$REMOTE_BUILD_DIR_CONTENTS' != ''){
+				if("${REMOTE_BUILD_DIR_CONTENTS}" != ''){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
                         		sh 'exit 1'
 				} else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,11 +137,11 @@ pipeline {
                         	echo "$BUILDSTARTDATE doesn't exist, proceeding"
 			}
     		        withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG')]) {
-		                GIT_COMMIT_EMAIL = sh (
+		                REMOTE_BUILD_DIR_CONTENTS = sh (
 		    	   	    script: 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate ls s3://kg-hub-public-data/$BUILDSTARTDATE/',
 		    	   	    returnStdout: true
 		                ).trim()
-		                echo "Git committer email: ${GIT_COMMIT_EMAIL}"			    
+		                echo "REMOTE_BUILD_DIR_CONTENTS: ${REMOTE_BUILD_DIR_CONTENTS}"			    
 			}
 		        sh 'git clone https://github.com/justaddcoffee/go-site.git'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,15 +93,10 @@ pipeline {
         stage('Merge') {
             steps {
                 dir('./gitrepo') {
-//                     sh '. venv/bin/activate && python3.7 run.py merge'
-//                     sh 'env'
-//                     sh 'cp merged_graph_stats.yaml merged_graph_stats_$BUILDSTARTDATE.yaml'
-//                     sh 'tar -rvf data/merged/merged-kg.tar merged_graph_stats_$BUILDSTARTDATE.yaml'
-                    sh 'touch TEST_stats.yaml'
-                    sh 'touch merged_graph_stats_$BUILDSTARTDATE.yaml'
-                    sh 'mkdir -p data/merged/'
-                    sh 'touch data/merged/merged-kg.nt.gz'
-                    sh 'touch data/merged/merged-kg.tar.gz'
+                    sh '. venv/bin/activate && python3.7 run.py merge'
+                    sh 'env'
+                    sh 'cp merged_graph_stats.yaml merged_graph_stats_$BUILDSTARTDATE.yaml'
+                    sh 'tar -rvf data/merged/merged-kg.tar merged_graph_stats_$BUILDSTARTDATE.yaml'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,10 +142,10 @@ pipeline {
                             echo "Will not push if not on correct branch."
                         } else {
                             withCredentials([
-					    file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG'),
-					    file(credentialsId: 'aws_kg_hub_push_json', variable: 'AWS_JSON'),
-					    string(credentialsId: 'aws_kg_hub_access_key', variable: 'AWS_ACCESS_KEY_ID'),
-					    string(credentialsId: 'aws_kg_hub_secret_key', variable: 'AWS_SECRET_ACCESS_KEY')]) {
+					            file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG'),
+					            file(credentialsId: 'aws_kg_hub_push_json', variable: 'AWS_JSON'),
+					            string(credentialsId: 'aws_kg_hub_access_key', variable: 'AWS_ACCESS_KEY_ID'),
+					            string(credentialsId: 'aws_kg_hub_secret_key', variable: 'AWS_SECRET_ACCESS_KEY')]) {
                                 //
                                 // make $BUILDSTARTDATE/ directory and sync to s3 bucket
                                 //

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,14 +172,6 @@ pipeline {
                                 sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/current -x -u'
                                 sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE/ s3://kg-hub-public-data/current/'
 
-                                //
-                                // make $BUILDSTARTDATE the new current/
-                                //
-				// The following cp always times out:
-                                // sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate cp -v -pr s3://kg-hub-public-data/$BUILDSTARTDATE/ s3://kg-hub-public-data/new_current/'
-                                // sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate rm -fr s3://kg-hub-public-data/current'
-                                // sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate mv --recursive s3://kg-hub-public-data/new_current/ s3://kg-hub-public-data/current/'
-
                         	// Build the top level index.html
 				// "External" packages required to run these
 				// scripts.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ pipeline {
 		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): ${REMOTE_BUILD_DIR_CONTENTS}"
 				if('$BUILDSTARTDATE'){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
-                        		// sh 'exit 1'
+                        		sh 'exit 1'
 				} else {
                         		echo "remote directory $BUILDSTARTDATE is empty, proceeding"
 				}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,9 +119,9 @@ pipeline {
 
         stage('Publish') {
             steps {
-                // code for building s3 index files
                 dir('./gitrepo') {
                     script {
+                        // code for building s3 index files
 			            sh 'git clone https://github.com/justaddcoffee/go-site.git'
 
 			            // make sure we aren't going to clobber existing data on S3

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,7 +152,6 @@ pipeline {
                                 sh 'mkdir $BUILDSTARTDATE/'
                                 sh 'cp -p data/merged/merged-kg.nt.gz $BUILDSTARTDATE/kg-covid-19.nt.gz'
                                 sh 'cp -p data/merged/merged-kg.tar.gz $BUILDSTARTDATE/kg-covid-19.tar.gz'
-                                sh 'touch merged-kg.jnl.gz' // REMOVE
                                 sh 'cp -p merged-kg.jnl.gz $BUILDSTARTDATE/kg-covid-19.jnl.gz'
                                 // transformed data
                                 sh 'rm -fr data/transformed/.gitkeep'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,22 +122,21 @@ pipeline {
                 // code for building s3 index files
                 dir('./gitrepo') {
                     script {
-			sh 'git clone https://github.com/justaddcoffee/go-site.git'
+			            sh 'git clone https://github.com/justaddcoffee/go-site.git'
 
-			// make sure we aren't going to clobber existing data
-    		        withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG')]) {
-		                REMOTE_BUILD_DIR_CONTENTS = sh (
-		    	   	    script: 's3cmd -c $S3CMD_CFG ls s3://kg-hub-public-data/$BUILDSTARTDATE/',
-		    	   	    returnStdout: true
-		                ).trim()
-		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): '${REMOTE_BUILD_DIR_CONTENTS}'"
-				if("${REMOTE_BUILD_DIR_CONTENTS}" != ''){
+			            // make sure we aren't going to clobber existing data on S3
+    		            withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG')]) {
+		                    REMOTE_BUILD_DIR_CONTENTS = sh (
+		    	   	            script: 's3cmd -c $S3CMD_CFG ls s3://kg-hub-public-data/$BUILDSTARTDATE/',
+		    	   	            returnStdout: true.trim()
+		                    echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): '${REMOTE_BUILD_DIR_CONTENTS}'"
+				            if("${REMOTE_BUILD_DIR_CONTENTS}" != ''){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
                         		sh 'exit 1'
-				} else {
+				            } else {
                         		echo "remote directory $BUILDSTARTDATE is empty, proceeding"
-				}
-			}
+				            }
+			            }
 
                         // if (env.BRANCH_NAME != 'master' ||
                         if (env.BRANCH_NAME == 'NOT THIS BRANCH') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,17 +61,17 @@ pipeline {
                             if (env.BRANCH_NAME != 'master') { // upload raw to s3 if we're on correct branch
                                 echo "Will not push if not on correct branch."
                             } else {
-                                withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_JSON')]) {
-                                    sh 's3cmd -c $S3CMD_JSON --acl-public --mime-type=plain/text --cf-invalidate put -r data/raw s3://kg-hub-public-data/'
+                                withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG')]) {
+                                    sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=plain/text --cf-invalidate put -r data/raw s3://kg-hub-public-data/'
                                 }
                             }
                         } else { // 'run.py download' failed - let's try to download last good copy of raw/ from s3 to data/
-                            withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_JSON')]) {
+                            withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG')]) {
                                 sh 'rm -fr data/raw || true;'
                                 sh 'mkdir -p data/raw || true'
 			        // FIX THIS
-                                // sh 's3cmd -c $S3CMD_JSON --acl-public --mime-type=plain/text get -r s3://kg-hub-public-data/raw/ data/raw/'
-			 	sh 's3cmd -c $S3CMD_JSON --acl-public --mime-type=plain/text get -r s3://kg-hub-public-data/raw/hp.json data/raw/hp.json'
+                                // sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=plain/text get -r s3://kg-hub-public-data/raw/ data/raw/'
+			 	sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=plain/text get -r s3://kg-hub-public-data/raw/hp.json data/raw/hp.json'
 
 			    }
                         }
@@ -85,9 +85,9 @@ pipeline {
                 dir('./gitrepo') {
 //                     sh 'env'
 //                     sh '. venv/bin/activate && env && python3.7 run.py transform'
-                    withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_JSON')]) {
+                    withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG')]) {
 		        sh 'mkdir transformed/'
-                        sh 's3cmd -c $S3CMD_JSON --acl-public --mime-type=plain/text get -r s3://kg-hub-public-data/transformed/ttd data/transformed/'
+                        sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=plain/text get -r s3://kg-hub-public-data/transformed/ttd data/transformed/'
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,7 +164,6 @@ pipeline {
 					    file(credentialsId: 'aws_kg_hub_push_json', variable: 'AWS_JSON'),
 					    string(credentialsId: 'aws_kg_hub_access_key', variable: 'AWS_ACCESS_KEY_ID'), 
 					    string(credentialsId: 'aws_kg_hub_secret_key', variable: 'AWS_SECRET_ACCESS_KEY')]) {
-				    ]) {
                                 //
                                 // make $BUILDSTARTDATE/ directory and sync to s3 bucket
                                 //

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,8 @@ pipeline {
         BUILDSTARTDATE = sh(script: "echo `date +%Y%m%d`", returnStdout: true).trim()
 
         // Distribution ID for the AWS CloudFront for this branch,
-	// used soley for invalidations
-	AWS_CLOUDFRONT_DISTRIBUTION_ID = 'EUVSWXZQBXCFP'
+        // used soley for invalidations
+        AWS_CLOUDFRONT_DISTRIBUTION_ID = 'EUVSWXZQBXCFP'
     }
 
     options {
@@ -159,7 +159,7 @@ pipeline {
                             withCredentials([
 					    file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG'),
 					    file(credentialsId: 'aws_kg_hub_push_json', variable: 'AWS_JSON'),
-					    string(credentialsId: 'aws_kg_hub_access_key', variable: 'AWS_ACCESS_KEY_ID'), 
+					    string(credentialsId: 'aws_kg_hub_access_key', variable: 'AWS_ACCESS_KEY_ID'),
 					    string(credentialsId: 'aws_kg_hub_secret_key', variable: 'AWS_SECRET_ACCESS_KEY')]) {
                                 //
                                 // make $BUILDSTARTDATE/ directory and sync to s3 bucket
@@ -190,7 +190,7 @@ pipeline {
 
                                 //
                                 // make $BUILDSTARTDATE the new current/
-                                // 	    
+                                //
 				// The following cp always times out:
                                 // sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate cp -v -pr s3://kg-hub-public-data/$BUILDSTARTDATE/ s3://kg-hub-public-data/new_current/'
                                 // sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate rm -fr s3://kg-hub-public-data/current'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -188,8 +188,8 @@ pipeline {
 				sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE s3://kg-hub-public-data/'
 
 			        // make current/ directory
-				sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory current --prefix https://kg-hub.berkeleybop.io/current -x -u'
-				sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE/ s3://kg-hub-public-data/new_current/'
+				sh '. venv/bin/activate && python3.7 ./go-site/scripts/directory_indexer.py -v --inject ./go-site/scripts/directory-index-template.html --directory $BUILDSTARTDATE --prefix https://kg-hub.berkeleybop.io/current -x -u'
+				sh 's3cmd -c $S3CMD_CFG put -pr --acl-public --mime-type=text/html --cf-invalidate $BUILDSTARTDATE/ s3://kg-hub-public-data/current/'
 
                                 //
                                 // make $BUILDSTARTDATE the new current/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,15 +143,8 @@ pipeline {
 		    	   	    returnStdout: true
 		                ).trim()
 		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): ${REMOTE_BUILD_DIR_CONTENTS}"
-				if($REMOTE_BUILD_DIR_CONTENTS){
-                        		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
-                        		sh 'exit 1'
-				} else {
-                        		echo "remote directory $BUILDSTARTDATE is empty, proceeding"
-				}
 			}
-			    
-			
+
 		        sh 'git clone https://github.com/justaddcoffee/go-site.git'
 
                         // if (env.BRANCH_NAME != 'master' ||

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,7 +135,7 @@ pipeline {
                         	echo "Will not overwrite existing directory: $BUILDSTARTDATE"
                         	sh 'exit 1'
 			} else {
-                        	echo "$BUILDSTARTDATE doesn't exist, proceeding"
+                        	echo "local directory $BUILDSTARTDATE doesn't exist, proceeding"
 			}
     		        withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG')]) {
 		                REMOTE_BUILD_DIR_CONTENTS = sh (
@@ -143,9 +143,11 @@ pipeline {
 		    	   	    returnStdout: true
 		                ).trim()
 		                echo "REMOTE_BUILD_DIR_CONTENTS: ${REMOTE_BUILD_DIR_CONTENTS}"
-				if($REMOTE_BUILD_DIR_CONTENTS){
+				if($REMOTE_BUILD_DIR_CONTENTS != ''){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
                         		sh 'exit 1'
+				} else {
+                        		echo "remote directory $BUILDSTARTDATE is empty, proceeding"
 				}
 			}
 			    

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,10 +5,7 @@ pipeline {
         BUILDSTARTDATE = sh(script: "echo `date +%Y%m%d`", returnStdout: true).trim()
 
         // Distribution ID for the AWS CloudFront for this branch,
-	// used soley for invalidations. Versioned release does not
-	// need this as it is always a new location and the index
-	// upload already has an invalidation on it. For current,
-	// snapshot, and experimental.
+	// used soley for invalidations
 	AWS_CLOUDFRONT_DISTRIBUTION_ID = 'EUVSWXZQBXCFP'
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,7 +136,14 @@ pipeline {
 			} else {
                         	echo "$BUILDSTARTDATE doesn't exist, proceeding"
 			}
-                        sh 'git clone https://github.com/justaddcoffee/go-site.git'
+    		        withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG')]) {
+		                GIT_COMMIT_EMAIL = sh (
+		    	   	    script: 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate ls s3://kg-hub-public-data/$BUILDSTARTDATE/',
+		    	   	    returnStdout: true
+		                ).trim()
+		                echo "Git committer email: ${GIT_COMMIT_EMAIL}"			    
+			}
+		        sh 'git clone https://github.com/justaddcoffee/go-site.git'
 
                         // if (env.BRANCH_NAME != 'master' ||
                         if (env.BRANCH_NAME == 'NOT THIS BRANCH') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,6 +129,7 @@ pipeline {
 		                    REMOTE_BUILD_DIR_CONTENTS = sh (
 		    	   	            script: 's3cmd -c $S3CMD_CFG ls s3://kg-hub-public-data/$BUILDSTARTDATE/',
 		    	   	            returnStdout: true.trim()
+                            )
 		                    echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): '${REMOTE_BUILD_DIR_CONTENTS}'"
 				            if("${REMOTE_BUILD_DIR_CONTENTS}" != ''){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,7 +137,7 @@ pipeline {
 		    	   	    returnStdout: true
 		                ).trim()
 		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): '${REMOTE_BUILD_DIR_CONTENTS}'"
-				if($REMOTE_BUILD_DIR_CONTENTS){
+				if($REMOTE_BUILD_DIR_CONTENTS != ''){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
                         		sh 'exit 1'
 				} else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,7 +182,7 @@ pipeline {
 				// scripts.
 				sh './venv/bin/pip install pystache boto3'
 				sh '. venv/bin/activate && python3.7 ./go-site/scripts/bucket-indexer.py --credentials $AWS_JSON --bucket kg-hub-public-data --inject ./go-site/scripts/directory-index-template.html --prefix https://kg-hub.berkeleybop.io/ > top-level-index.html'
-				sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate sync top-level-index.html s3://kg-hub-public-data/index.html'
+				sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate cp top-level-index.html s3://kg-hub-public-data/index.html'
 
                                 // Should now appear at:
                                 // https://kg-hub.berkeleybop.io/[artifact name]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,22 +122,22 @@ pipeline {
                 dir('./gitrepo') {
                     script {
                         // code for building s3 index files
-			            sh 'git clone https://github.com/justaddcoffee/go-site.git'
+                        sh 'git clone https://github.com/justaddcoffee/go-site.git'
 
-			            // make sure we aren't going to clobber existing data on S3
-    		            withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG')]) {
-		                    REMOTE_BUILD_DIR_CONTENTS = sh (
-		    	   	            script: 's3cmd -c $S3CMD_CFG ls s3://kg-hub-public-data/$BUILDSTARTDATE/',
-		    	   	            returnStdout: true.trim()
+                        // make sure we aren't going to clobber existing data on S3
+                        withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG')]) {
+                            REMOTE_BUILD_DIR_CONTENTS = sh (
+                                script: 's3cmd -c $S3CMD_CFG ls s3://kg-hub-public-data/$BUILDSTARTDATE/',
+                                returnStdout: true.trim()
                             )
-		                    echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): '${REMOTE_BUILD_DIR_CONTENTS}'"
-				            if("${REMOTE_BUILD_DIR_CONTENTS}" != ''){
-                        		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
-                        		sh 'exit 1'
-				            } else {
-                        		echo "remote directory $BUILDSTARTDATE is empty, proceeding"
-				            }
-			            }
+                            echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): '${REMOTE_BUILD_DIR_CONTENTS}'"
+                            if("${REMOTE_BUILD_DIR_CONTENTS}" != ''){
+                                echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
+                                sh 'exit 1'
+                            } else {
+                                echo "remote directory $BUILDSTARTDATE is empty, proceeding"
+                            }
+                        }
 
                         if (env.BRANCH_NAME != 'master') {
                             echo "Will not push if not on correct branch."

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,12 +84,8 @@ pipeline {
         stage('Transform') {
             steps {
                 dir('./gitrepo') {
-//                     sh 'env'
-//                     sh '. venv/bin/activate && env && python3.7 run.py transform'
-                    withCredentials([file(credentialsId: 's3cmd_kg_hub_push_configuration', variable: 'S3CMD_CFG')]) {
-		        sh 'mkdir transformed/'
-                        sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=plain/text get -r s3://kg-hub-public-data/transformed/ttd data/transformed/'
-                    }
+                    sh 'env'
+                    sh '. venv/bin/activate && env && python3.7 run.py transform'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -193,7 +193,7 @@ pipeline {
 				// The following cp always times out:
                                 sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate cp -v -pr s3://kg-hub-public-data/$BUILDSTARTDATE/ s3://kg-hub-public-data/new_current/'
                                 sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate rm -fr s3://kg-hub-public-data/current'
-                                sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate mv --recursive s3://kg-hub-public-data/new_current s3://kg-hub-public-data/current'
+                                sh 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate mv --recursive s3://kg-hub-public-data/new_current s3://kg-hub-public-data/current/'
 
                         	// Build the top level index.html
 				// "External" packages required to run these

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,8 +142,8 @@ pipeline {
 		    	   	    script: 's3cmd -c $S3CMD_CFG --acl-public --mime-type=text/html --cf-invalidate ls s3://kg-hub-public-data/$BUILDSTARTDATE/',
 		    	   	    returnStdout: true
 		                ).trim()
-		                echo "REMOTE_BUILD_DIR_CONTENTS: ${REMOTE_BUILD_DIR_CONTENTS}"
-				if($REMOTE_BUILD_DIR_CONTENTS != ''){
+		                echo "REMOTE_BUILD_DIR_CONTENTS (THIS SHOULD BE EMPTY): ${REMOTE_BUILD_DIR_CONTENTS}"
+				if($REMOTE_BUILD_DIR_CONTENTS){
                         		echo "Will not overwrite existing (---REMOTE S3---) directory: $BUILDSTARTDATE"
                         		sh 'exit 1'
 				} else {


### PR DESCRIPTION
To address #135 and also MS reviewers' request that we provide versioning for our builds

This PR:
- writes out all files for a build to a timestamped directory eg. 20201231 (including 
    - merged graph in TSV format
    - an RDF version of the merged graph
    - the `raw/` directory with the data ingested to make build
    - the `transformed/` directory containing subgraphs
    - a `stats` directory with statistics about the build
    - the `Jenkinsfile` containing that actually ran the build
- copies this directory to a current/ directory so users can have a URL to retrieve the most current build
- also adds index.html files to each of the directories mentioned above, to allow browsing/listing of contents for directories