### PR TITLE
pin ensmallen_graph to 0.3.6 for now to pass tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         'pyyaml',
         'bmt',
         'SPARQLWrapper',
-        'ensmallen_graph'
+        'ensmallen_graph==0.3.6'
     ],
     extras_require=extras,
 )


### PR DESCRIPTION
Updated ensmallen_graph causes a panic in 
` TestEdges.test_make_edges_pos_train_test_valid_edges_distinct_1_neg_train_edges_tsv`:
```
        neg_train_edges, neg_test_edges = \
>           all_negative_edges.random_holdout(seed=seed, train_percentage=train_fraction)
E       pyo3_runtime.PanicException: index out of bounds: the len is 0 but the index is 53
```

Pinned to 0.3.6 for now