### PR TITLE
Produce nt only in jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,7 +98,7 @@ pipeline {
         stage('Merge') {
             steps {
                 dir('./gitrepo') {
-                    sh '. venv/bin/activate && python3.7 run.py merge'
+                    sh '. venv/bin/activate && python3.7 run.py merge -y merge_jenkins.yaml'
                     sh 'env'
                     sh 'cp merged_graph_stats.yaml merged_graph_stats_$BUILDSTARTDATE.yaml'
                     sh 'tar -rvf data/merged/merged-kg.tar merged_graph_stats_$BUILDSTARTDATE.yaml'

--- a/merge.yaml
+++ b/merge.yaml
@@ -123,10 +123,10 @@ merged_graph:
       type: tsv
       compression: tar.gz
       filename: merged-kg
-    merged-kg-nt:
-      type: nt
-      compression: gz
-      filename: merged-kg.nt.gz
+#    merged-kg-nt:
+#      type: nt
+#      compression: gz
+#      filename: merged-kg.nt.gz
 #    merged-kg-neo4j:
 #      type: neo4j
 #      uri: http://localhost:8484

--- a/merge_jenkins.yaml
+++ b/merge_jenkins.yaml
@@ -1,0 +1,134 @@
+---
+configuration:
+  output_directory: data/merged
+  checkpoint: false
+  property_types:
+    # define the type for non-canonical node/edge properties
+    combined_score: 'xsd:float'
+    confidence_score: 'xsd:float'
+    neighborhood: 'xsd:float'
+    neighborhood_transferred: 'xsd:float'
+    fusion: 'xsd:float'
+    cooccurence: 'xsd:float'
+    homology: 'xsd:float'
+    coexpression: 'xsd:float'
+    coexpression_transferred: 'xsd:float'
+    experiments: 'xsd:float'
+    experiments_transferred: 'xsd:float'
+    database: 'xsd:float'
+    database_transferred: 'xsd:float'
+    textmining: 'xsd:float'
+    textmining_transferred: 'xsd:float'
+
+merged_graph:
+  name: KG-COVID-19 Graph
+  targets:
+    drug-central:
+      type: tsv
+      filename:
+        - data/transformed/drug_central/nodes.tsv
+        - data/transformed/drug_central/edges.tsv
+    pharmgkb:
+      type: tsv
+      filename:
+        - data/transformed/pharmgkb/nodes.tsv
+        - data/transformed/pharmgkb/edges.tsv
+    STRING:
+      type: tsv
+      filename:
+        - data/transformed/STRING/nodes.tsv
+        - data/transformed/STRING/edges.tsv
+      filters:
+        node_filters:
+          category:
+            - biolink:Gene
+            - biolink:Protein
+        edge_filters:
+          subject_category:
+            - biolink:Gene
+            - biolink:Protein
+          object_category:
+            - biolink:Gene
+            - biolink:Protein
+          edge_label:
+            - biolink:interacts_with
+            - biolink:has_gene_product
+      operations:
+        - name: kgx.utils.graph_utils.remap_node_identifier
+          args:
+            category: biolink:Protein
+            alternative_property: xrefs
+            prefix: UniProtKB
+    ttd:
+      type: tsv
+      filename:
+        - data/transformed/ttd/nodes.tsv
+        - data/transformed/ttd/edges.tsv
+    zhou-host-proteins:
+      type: tsv
+      filename:
+        - data/transformed/zhou_host_proteins/nodes.tsv
+        - data/transformed/zhou_host_proteins/edges.tsv
+    SciBite-CORD-19:
+      type: tsv
+      filename:
+        - data/transformed/SciBite-CORD-19/nodes.tsv
+        - data/transformed/SciBite-CORD-19/edges.tsv
+    sars-cov-2-gene-annot:
+      type: tsv
+      filename:
+        - data/transformed/sars_cov_2_gene_annot/nodes.tsv
+        - data/transformed/sars_cov_2_gene_annot/edges.tsv
+    intact:
+      type: tsv
+      filename:
+        - data/transformed/intact/nodes.tsv
+        - data/transformed/intact/edges.tsv
+    chembl:
+      type: tsv
+      filename:
+        - data/transformed/ChEMBL/nodes.tsv
+        - data/transformed/ChEMBL/edges.tsv
+    gene-ontology:
+      type: tsv
+      filename:
+        - data/transformed/ontologies/go-plus_nodes.tsv
+        - data/transformed/ontologies/go-plus_edges.tsv
+    mondo-ontology:
+      type: tsv
+      filename:
+        - data/transformed/ontologies/mondo_nodes.tsv
+        - data/transformed/ontologies/mondo_edges.tsv
+    hp-ontology:
+      type: tsv
+      filename:
+        - data/transformed/ontologies/hp_nodes.tsv
+        - data/transformed/ontologies/hp_edges.tsv
+    go-cams:
+      type: tsv
+      filename:
+        - data/transformed/GOCAMs/GOCAMs_nodes.tsv
+        - data/transformed/GOCAMs/GOCAMs_edges.tsv
+  operations:
+    - name: kgx.operations.summarize_graph.generate_graph_stats
+      args:
+        graph_name: KG-COVID-19 Graph
+        filename: merged_graph_stats.yaml
+        node_facet_properties:
+          - provided_by
+        edge_facet_properties:
+          - provided_by
+  destination:
+    merged-kg-tsv:
+      type: tsv
+      compression: tar.gz
+      filename: merged-kg
+    merged-kg-nt:
+      type: nt
+      compression: gz
+      filename: merged-kg.nt.gz
+#    merged-kg-neo4j:
+#      type: neo4j
+#      uri: http://localhost:8484
+#      username: neo4j
+#      password: admin


### PR DESCRIPTION
Slight change such that nt/rdf is not produced from `run.py merge` by default, but only in Jenkins pipeline