### PR TITLE
Update chembl

### DIFF
--- a/kg_covid_19/merge_utils/merge_kg.py
+++ b/kg_covid_19/merge_utils/merge_kg.py
@@ -3,8 +3,8 @@ import logging
 import os
 from typing import Dict, List
 import yaml
-import networkx as nx
-from kgx.cli.cli_utils import merge
+import networkx as nx  # type: ignore
+from kgx.cli.cli_utils import merge  # type: ignore
 
 
 def parse_load_config(yaml_file: str) -> Dict:

--- a/kg_covid_19/merge_utils/merge_kg.py
+++ b/kg_covid_19/merge_utils/merge_kg.py
@@ -1,7 +1,4 @@
-import importlib
-import logging
-import os
-from typing import Dict, List
+from typing import Dict
 import yaml
 import networkx as nx  # type: ignore
 from kgx.cli.cli_utils import merge  # type: ignore

--- a/kg_covid_19/transform_utils/chembl/chembl_transform.py
+++ b/kg_covid_19/transform_utils/chembl/chembl_transform.py
@@ -163,7 +163,7 @@ class ChemblTransform(Transform):
         Returns:
             A list
         """
-        node_category = ['biolink:ChemicalSubstance']
+        node_category = ['biolink:Drug']
         allowed_properties = {
             'molecule_type', 'polymer_flag', 'inorganic_flag', 'natural_product',
             'synonyms', 'molecule_properties', 'canonical_smiles', 'full_molformula',

--- a/kg_covid_19/transform_utils/chembl/chembl_transform.py
+++ b/kg_covid_19/transform_utils/chembl/chembl_transform.py
@@ -89,6 +89,15 @@ class ChemblTransform(Transform):
                 data=[n[x] if x in n else '' for x in sorted(self.node_header)]
             )
 
+        # write node for organisms in TAXON_MAP
+        for org_curie, org_name in {v: k for k, v in TAXON_MAP.items()}.items():
+            o = {'id': org_curie, 'name': org_name, 'category': 'biolink:OrganismTaxon'}
+            write_node_edge_item(
+                fh=node_handle,
+                header=sorted(self.node_header),
+                data=[o[x] if x in o else '' for x in sorted(self.node_header)]
+            )
+
         for e in activity_edges:
             write_node_edge_item(
                 fh=edge_handle,


### PR DESCRIPTION
- Change node category to `biolink:`~~Category~~`Drug` instead of `biolink:ChemicalSubstance`
- Add a node for each item in TAXON_MAP (solves issue encountered by @LucaCappelletti94 when ingesting ChEMBL subgraph without the rest of the graph - in this case, we end up with `NCBITaxon:2697049` mentioned in edge file but not in the node file