### PR TITLE
Workaround to standardize GOCAM edge/node file names

### DIFF
--- a/kg_covid_19/transform_utils/gocam_transform/gocam_transform.py
+++ b/kg_covid_19/transform_utils/gocam_transform/gocam_transform.py
@@ -1,6 +1,6 @@
 import gzip
+import logging
 import os
-import shutil
 from typing import Optional
 
 from kgx import RdfTransformer, PandasTransformer # type: ignore
@@ -82,6 +82,13 @@ class GocamTransform(Transform):
         transformer.parse(data_file, node_property_predicates=np, input_format=input_format)
         output_transformer = PandasTransformer(transformer.graph)
         output_transformer.save(os.path.join(self.output_dir, self.source_name), output_format='tsv', mode=None)
+
+        for ftype in ["edges.tsv", "nodes.tsv"]:
+            old_fname: str = "_".join([os.path.join(self.output_dir, self.source_name), ftype])
+            new_fname: str = os.path.join(self.output_dir, ftype)
+            if not os.path.exists(old_fname):
+                logging.error(f"file {old_fname} doesn't exist")
+            os.rename(old_fname, new_fname)
 
     def decompress_file(self, input_file: str, output_file: str):
         """Decompress a file.

--- a/merge.yaml
+++ b/merge.yaml
@@ -112,8 +112,8 @@ merged_graph:
     go-cams:
       type: tsv
       filename:
-        - data/transformed/GOCAMs/GOCAMs_nodes.tsv
-        - data/transformed/GOCAMs/GOCAMs_edges.tsv
+        - data/transformed/GOCAMs/nodes.tsv
+        - data/transformed/GOCAMs/edges.tsv
   operations:
     - name: kgx.operations.summarize_graph.generate_graph_stats
       args:


### PR DESCRIPTION
To address #394 

@deepakunni3 can you have a look and see if there is a better way of telling KGX to emit `edges.tsv` and `nodes.tsv` files? 

I don't see any way of passing filenames to `output_transformer.save()` [here](https://github.com/Knowledge-Graph-Hub/kg-covid-19/blob/18505c2603fcdb6233a7cdf4e956c5489fc6dea8/kg_covid_19/transform_utils/gocam_transform/gocam_transform.py#L84) in a way that files are names `edges.tsv` and `nodes.tsv`