### PR TITLE
Fix SPARQL queries metadata for grlc API

### DIFF
--- a/queries/query-02-sars-cov-2-prot.rq
+++ b/queries/query-02-sars-cov-2-prot.rq
@@ -1,6 +1,6 @@
-#+ title Get SARS-CoV-2 proteins
-#+ description Get info about SARS-CoV-2 proteins in the graph
-#+ endpoint http://kg-hub-rdf.berkeleybop.io/blazegraph/sparql
+#+ summary: Get SARS-CoV-2 proteins
+#+ description: Get info about SARS-CoV-2 proteins in the graph
+#+ endpoint: http://kg-hub-rdf.berkeleybop.io/blazegraph/sparql
 
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/queries/query-03-sars-cov-2-interactors.rq
+++ b/queries/query-03-sars-cov-2-interactors.rq
@@ -1,6 +1,6 @@
-#+ title Get human proteins that interact with SARS-CoV-2 proteins
-#+ description Get human proteins that interact with SARS-CoV-2 proteins
-#+ endpoint http://kg-hub-rdf.berkeleybop.io/blazegraph/sparql
+#+ summary: Get human proteins that interact with SARS-CoV-2 proteins
+#+ description: Get human proteins that interact with SARS-CoV-2 proteins
+#+ endpoint: http://kg-hub-rdf.berkeleybop.io/blazegraph/sparql
 
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/queries/query-04-sars-cov-2-interactors_2nd_order.rq
+++ b/queries/query-04-sars-cov-2-interactors_2nd_order.rq
@@ -1,6 +1,6 @@
-#+ title Get 2nd order interactors
-#+ description Get human proteins that interact human proteins that interact with SARS-CoV-2 proteins
-#+ endpoint http://kg-hub-rdf.berkeleybop.io/blazegraph/sparql
+#+ summary: Get 2nd order interactors
+#+ description: Get human proteins that interact human proteins that interact with SARS-CoV-2 proteins
+#+ endpoint: http://kg-hub-rdf.berkeleybop.io/blazegraph/sparql
 
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>

--- a/queries/query-05-sars-cov-2-interactors_druggable_2nd_order.rq
+++ b/queries/query-05-sars-cov-2-interactors_druggable_2nd_order.rq
@@ -1,6 +1,6 @@
-#+ title Get druggable 2nd order interactors
-#+ description Get druggable (Tclind) human proteins that interact human proteins that interact with SARS-CoV-2 proteins, along with the relevant drugs
-#+ endpoint http://kg-hub-rdf.berkeleybop.io/blazegraph/sparql
+#+ summary: Get druggable 2nd order interactors
+#+ description: Get druggable (Tclind) human proteins that interact human proteins that interact with SARS-CoV-2 proteins, along with the relevant drugs
+#+ endpoint: http://kg-hub-rdf.berkeleybop.io/blazegraph/sparql
 
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>

--- a/queries/query-06-provided_by_counts.rq
+++ b/queries/query-06-provided_by_counts.rq
@@ -1,6 +1,6 @@
-#+ title Get counts by provided_by property
-#+ description Get counts by provided_by property
-#+ endpoint http://kg-hub-rdf.berkeleybop.io/blazegraph/sparql
+#+ summary: Get counts by provided_by property
+#+ description: Get counts by provided_by property
+#+ endpoint: http://kg-hub-rdf.berkeleybop.io/blazegraph/sparql
 
 PREFIX bl: <https://w3id.org/biolink/vocab/>
 SELECT (COUNT(?v2) AS ?v1) ?v0

--- a/queries/query-07-drug-to-drug-target.rq
+++ b/queries/query-07-drug-to-drug-target.rq
@@ -1,6 +1,6 @@
-#+ title Get drugs and their human protein targets
-#+ description Get drugs and their human protein targets
-#+ endpoint http://kg-hub-rdf.berkeleybop.io/blazegraph/sparql
+#+ summary: Get drugs and their human protein targets
+#+ description: Get drugs and their human protein targets
+#+ endpoint: http://kg-hub-rdf.berkeleybop.io/blazegraph/sparql
 
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>


### PR DESCRIPTION
Related to the previous pull request to fix grlc API SPARQL queries: https://github.com/Knowledge-Graph-Hub/kg-covid-19/pull/396#issuecomment-780754210

Added missing `:` in the grlc metadata and replaced `title` by `summary`