### PR TITLE
Add Chebi to merged graph

### DIFF
--- a/merge_jenkins.yaml
+++ b/merge_jenkins.yaml
@@ -99,6 +99,11 @@ merged_graph:
       filename:
         - data/transformed/ontologies/mondo_nodes.tsv
         - data/transformed/ontologies/mondo_edges.tsv
+    chebi:
+      type: tsv
+      filename:
+        - data/transformed/ontologies/chebi_nodes.tsv
+        - data/transformed/ontologies/chebi_edges.tsv
     hp-ontology:
       type: tsv
       filename:


### PR DESCRIPTION
This block was missing from `merge_jenkins.yaml`:
```
    chebi:
      type: tsv
      filename:
        - data/transformed/ontologies/chebi_nodes.tsv
        - data/transformed/ontologies/chebi_edges.tsv
```
So chebi wasn't actually making it into the merged graph. This PR fixes that