### PR TITLE
Refine scibite biolink edge type

### DIFF
--- a/kg_covid_19/transform_utils/scibite_cord/scibite_cord.py
+++ b/kg_covid_19/transform_utils/scibite_cord/scibite_cord.py
@@ -207,9 +207,9 @@ class ScibiteCordTransform(Transform):
                 fh=edge_handle,
                 header=self.edge_header,
                 data=[
-                    f"{curie}",
-                    f"biolink:related_to",
                     f"CORD:{paper_id}",
+                    f"biolink:mentions",
+                    f"{curie}",
                     "SIO:000255",
                     provided_by,
                     "biolink:Association"


### PR DESCRIPTION
Per Monarch data discussion, instead of this edge:
` [some science thing] biolink:related_to CORD:paper`
make this edge:
`CORD:paper biolink:mentions [some science thing]`

