### PR TITLE
Add cleanws to post stage in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -247,7 +247,9 @@ pipeline {
 
     post {
         always {
-            echo 'Nothing to do (in always)'
+            echo 'In always'
+            echo 'Cleaning workspace...'
+            cleanWs()
         }
         success {
             echo 'I succeeded!'


### PR DESCRIPTION
It's evident that previous runs in a given workspace are causing some issues here:
- download stages are clearly using existing data from previous runs instead of download fresh data
- blazegraph journal file from previous runs still exist, causing unexpected behavior (pigz dies with unhelpful message caused by it wanting to talk to an interactive terminal to ask whether it should overwrite existing file)
- git repo from previous run still exists, causing git clone to fail

Adding cleanWs() to the post stage should fix this