### PR TITLE
Re-add ssh-keyscan

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -228,6 +228,12 @@ pipeline {
 
                     withCredentials([file(credentialsId: 'ansible-bbop-local-slave', variable: 'DEPLOY_LOCAL_IDENTITY')]) {
                         echo 'Push master out to public Blazegraph'
+			    
+			// these commands ensure that ansible's ssh command doesn't
+                        // fail (in a very difficult-to-debug way) when it needs
+                        // us to accept the public key of pan.lbl.gov
+                        sh 'mkdir -p ~/.ssh/'
+                        sh 'ssh-keyscan -H 3.221.221.206 >> ~/.ssh/known_hosts'
 
                         retry(3){
                             sh 'HOME=`pwd` && ansible-playbook update-kg-hub-endpoint.yaml --inventory=hosts.remote-rdf-endpoint --private-key="$DEPLOY_LOCAL_IDENTITY" -e target_user=ubuntu --extra-vars="endpoint=internal"'


### PR DESCRIPTION
Pushing to public Blazegraph was failing with 
```
Failed to connect to the host via ssh: Host key verification failed.
```
This adds the ssh-keyscan call back in to retrieve SSH host keys.